### PR TITLE
Feat: User, Location 엔티티 추가 #12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // JPA Json 타입 매핑용
+    implementation 'com.vladmihalcea:hibernate-types-60:2.20.0'
 }
 
 

--- a/src/main/java/com/codeit/weatherwear/location/entity/Location.java
+++ b/src/main/java/com/codeit/weatherwear/location/entity/Location.java
@@ -1,0 +1,41 @@
+package com.codeit.weatherwear.location.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "locations")
+@Getter
+@NoArgsConstructor
+public class Location {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(updatable = false)
+    private UUID id;
+
+    private double latitude;
+
+    private double longitude;
+
+    private int x;
+
+    private int y;
+
+    private String name;
+
+    public Location(double latitude, double longitude, int x, int y, String name) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.x = x;
+        this.y = y;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/codeit/weatherwear/location/repository/LocationRepository.java
+++ b/src/main/java/com/codeit/weatherwear/location/repository/LocationRepository.java
@@ -3,7 +3,9 @@ package com.codeit.weatherwear.location.repository;
 import com.codeit.weatherwear.location.entity.Location;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface LocationRepository extends JpaRepository<Location, UUID> {
 
 }

--- a/src/main/java/com/codeit/weatherwear/location/repository/LocationRepository.java
+++ b/src/main/java/com/codeit/weatherwear/location/repository/LocationRepository.java
@@ -1,0 +1,9 @@
+package com.codeit.weatherwear.location.repository;
+
+import com.codeit.weatherwear.location.entity.Location;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LocationRepository extends JpaRepository<Location, UUID> {
+
+}

--- a/src/main/java/com/codeit/weatherwear/user/entity/Gender.java
+++ b/src/main/java/com/codeit/weatherwear/user/entity/Gender.java
@@ -1,0 +1,7 @@
+package com.codeit.weatherwear.user.entity;
+
+public enum Gender {
+    MALE,
+    FEMALE,
+    OTHER
+}

--- a/src/main/java/com/codeit/weatherwear/user/entity/OAuthProvider.java
+++ b/src/main/java/com/codeit/weatherwear/user/entity/OAuthProvider.java
@@ -1,0 +1,6 @@
+package com.codeit.weatherwear.user.entity;
+
+public enum OAuthProvider {
+    google,
+    kakao
+}

--- a/src/main/java/com/codeit/weatherwear/user/entity/Role.java
+++ b/src/main/java/com/codeit/weatherwear/user/entity/Role.java
@@ -1,0 +1,6 @@
+package com.codeit.weatherwear.user.entity;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/codeit/weatherwear/user/entity/User.java
+++ b/src/main/java/com/codeit/weatherwear/user/entity/User.java
@@ -4,6 +4,7 @@ import com.codeit.weatherwear.location.entity.Location;
 import com.vladmihalcea.hibernate.type.json.JsonType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
@@ -22,11 +23,15 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Type;
 import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "users")
 @Getter
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class User {
 
     @Id
@@ -34,10 +39,12 @@ public class User {
     @Column(updatable = false)
     private UUID id;
 
-    @Column(name = "created_at", nullable = false)
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
     private Instant createdAt;
 
-    @Column(name = "updated_at")
+    @LastModifiedDate
+    @Column(name = "updated_at", updatable = true)
     private Instant updatedAt;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/codeit/weatherwear/user/entity/User.java
+++ b/src/main/java/com/codeit/weatherwear/user/entity/User.java
@@ -1,0 +1,80 @@
+package com.codeit.weatherwear.user.entity;
+
+import com.codeit.weatherwear.location.entity.Location;
+import com.vladmihalcea.hibernate.type.json.JsonType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(updatable = false)
+    private UUID id;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(nullable = false)
+    private Role role = Role.USER;
+
+    @Column(nullable = false)
+    private boolean locked = false;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    private Gender gender;
+
+    @Column(name = "birth_date")
+    private LocalDate birthDate;
+
+    @Column(name = "temperature_sensitivity")
+    private int temperatureSensitivity;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Type(JsonType.class)
+    @Column(name = "linked_oauth_providers", columnDefinition = "jsonb")
+    private List<OAuthProvider> linkedOAuthProviders;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id")
+    private Location location;
+}

--- a/src/main/java/com/codeit/weatherwear/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/weatherwear/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.user.repository;
+
+import com.codeit.weatherwear.user.entity.User;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, UUID> {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
   servlet:
     multipart:
       enabled: true
+  config:
+    import: optional:file:.env[.properties]
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
## #️⃣ 연관 이슈
#12 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

feat/12/user-location-entity -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- User, Location 엔티티와 레포지토리를 추가했습니다.

- application-dev.yml에서 DB 정보를 환경변수로 읽는 방식으로 설정되어 있었으나 .env를 인식하지 못하는 문제가 있어 DB 연결이 안 됐습니다.
그래서 application.yml에 다음과 같이 추가했습니다.
```
spring:
    config:
       import: optional:file:.env[.properties]
```
### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

DB에 테스트 데이터를 넣어 엔티티의 속성들이 제대로 출력되는지 확인하였습니다.
임시 코드였으므로 따로 첨부하지는 않겠습니다.

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

### 새롭게 알게 된 점

User 테이블에는 Oauth 연결 정보(linkedOAuthProviders)가 json 배열(jsonb)로 저장되어야 합니다. 
그래서 제가 jsonb와 List<Enum> 컨버터가 따로 필요하다고 했는데 기억나시나요?
hibernate-types-60 라이브러리를 이용하면 JPA에서는 기본적으로 매핑할 수 없는 데이터 타입들을 쉽게 다룰 수 있다고 합니다!
json, jsonb 매핑을 지원하여 엔티티 클래스 해당 컬럼에 ` @Type(JsonType.class)`만 명시해주면 됩니다.

