### PR TITLE
Feat: OOTD 서비스 로직 기본 구현

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/ootd/mapper/OotdMapper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/ootd/mapper/OotdMapper.java
@@ -1,0 +1,32 @@
+package com.codeit.weatherwear.domain.ootd.mapper;
+
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
+import com.codeit.weatherwear.domain.ootd.entity.Ootd;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OotdMapper {
+
+  public Ootd toEntity(Feed feed, UUID clotheId) {
+    return Ootd.builder()
+        .feed(feed)
+        .clothesId(clotheId)
+        .build();
+  }
+
+  public OotdDto toDto(Ootd ootd) {
+    // todo: name 부터 아래는 clothes의 요소라 추후 Clothes 추가 시 수정할 예정
+    return OotdDto.builder()
+        .clothesId(ootd.getClothesId())
+        .name("임시 옷 이름")
+        .imageUrl(null)
+        .type(null)
+        .attributes(null)
+        .build();
+  }
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/ootd/repository/OotdRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/ootd/repository/OotdRepository.java
@@ -1,11 +1,16 @@
 package com.codeit.weatherwear.domain.ootd.repository;
 
 import com.codeit.weatherwear.domain.ootd.entity.Ootd;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OotdRepository extends JpaRepository<Ootd, UUID> {
 
+  @Query("select o from Ootd o where o.feed.id = :feedId")
+  List<Ootd> findByFeedId(@Param("feedId") UUID feedId);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/ootd/service/OotdService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/ootd/service/OotdService.java
@@ -1,0 +1,19 @@
+package com.codeit.weatherwear.domain.ootd.service;
+
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
+import java.util.List;
+import java.util.UUID;
+
+public interface OotdService {
+
+  // OOTD 생성
+  List<OotdDto> createOotdList(Feed feed, List<UUID> clothIds);
+
+  // OOTD 값 전달
+  List<OotdDto> findOotdByFeedId(UUID feedId);
+
+  // OOTD 삭제
+  List<OotdDto> deleteOotdByFeedId(UUID feedId);
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImpl.java
@@ -1,0 +1,64 @@
+package com.codeit.weatherwear.domain.ootd.service.impl;
+
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
+import com.codeit.weatherwear.domain.ootd.entity.Ootd;
+import com.codeit.weatherwear.domain.ootd.mapper.OotdMapper;
+import com.codeit.weatherwear.domain.ootd.repository.OotdRepository;
+import com.codeit.weatherwear.domain.ootd.service.OotdService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OotdServiceImpl implements OotdService {
+
+  private final OotdRepository ootdRepository;
+  private final OotdMapper ootdMapper;
+
+  @Transactional
+  @Override
+  public List<OotdDto> createOotdList(Feed feed, List<UUID> clothIds) {
+
+    if (clothIds == null || clothIds.isEmpty()) {
+      return List.of();
+    }
+
+//    List<Clothes> clothesList = clothIds.stream()
+//        .map(clothId -> clothesRepository.findById(clothId).orElseThrow()).toList();
+
+    // todo: 추후 Clothes 객체가 있으면 위 주석처리 된 옷 객체로 바꾸면 됨!
+    List<Ootd> ootdList = clothIds.stream().map(
+            clothId -> ootdMapper.toEntity(feed, clothId)
+        )
+        .toList();
+
+    List<Ootd> savedList = ootdRepository.saveAll(ootdList);
+
+    return savedList.stream().map(ootdMapper::toDto).toList();
+  }
+
+  @Transactional
+  @Override
+  public List<OotdDto> findOotdByFeedId(UUID feedId) {
+
+    List<Ootd> ootds = ootdRepository.findByFeedId(feedId);
+
+    return ootds.stream().map(ootdMapper::toDto).toList();
+  }
+
+  @Transactional
+  @Override
+  public List<OotdDto> deleteOotdByFeedId(UUID feedId) {
+
+    List<Ootd> ootds = ootdRepository.findByFeedId(feedId);
+    ootdRepository.deleteAll(ootds);
+
+    return ootds.stream().map(ootdMapper::toDto).toList();
+  }
+}

--- a/src/test/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImplTest.java
@@ -48,6 +48,7 @@ class OotdServiceImplTest {
   private UUID clothId1;
   private UUID clothId2;
 
+  private List<Ootd> ootdList;
   private Ootd mockOotd1;
   private OotdDto mockOotdDto1;
   private Ootd mockOotd2;
@@ -83,6 +84,7 @@ class OotdServiceImplTest {
         .type("하의")
         .attributes(null)
         .build();
+    ootdList = List.of(mockOotd1, mockOotd2);
 
     mockLocation = new Location(37.513068, 127.102570, 961159, 1953082, "서울 송파구 신천동");
 
@@ -122,8 +124,7 @@ class OotdServiceImplTest {
     // given
     given(ootdMapper.toEntity(mockFeed, clothId1)).willReturn(mockOotd1);
     given(ootdMapper.toEntity(mockFeed, clothId2)).willReturn(mockOotd2);
-    given(ootdRepository.saveAll(List.of(mockOotd1, mockOotd2))).willReturn(
-        List.of(mockOotd1, mockOotd2));
+    given(ootdRepository.saveAll(ootdList)).willReturn(ootdList);
     given(ootdMapper.toDto(mockOotd1)).willReturn(mockOotdDto1);
     given(ootdMapper.toDto(mockOotd2)).willReturn(mockOotdDto2);
 
@@ -133,7 +134,7 @@ class OotdServiceImplTest {
     // then
     then(ootdMapper).should().toEntity(mockFeed, clothId1);
     then(ootdMapper).should().toEntity(mockFeed, clothId2);
-    then(ootdRepository).should().saveAll(List.of(mockOotd1, mockOotd2));
+    then(ootdRepository).should().saveAll(ootdList);
     then(ootdMapper).should(times(1)).toDto(mockOotd1);
     then(ootdMapper).should(times(1)).toDto(mockOotd2);
 
@@ -160,5 +161,45 @@ class OotdServiceImplTest {
         .isNotNull()
         .isEmpty();
   }
+
+  @Test
+  @DisplayName("feedId를 받아 성공적으로 값을 가져온다.")
+  void findOotd_success() {
+    // given
+    given(ootdRepository.findByFeedId(feedId)).willReturn(ootdList);
+    given(ootdMapper.toDto(mockOotd1)).willReturn(mockOotdDto1);
+    given(ootdMapper.toDto(mockOotd2)).willReturn(mockOotdDto2);
+
+    // when
+    List<OotdDto> result = ootdService.findOotdByFeedId(feedId);
+
+    // then
+    then(ootdRepository).should(times(1)).findByFeedId(feedId);
+    then(ootdMapper).should(times(1)).toDto(mockOotd1);
+    then(ootdMapper).should(times(1)).toDto(mockOotd2);
+
+    assertThat(result)
+        .hasSize(2)
+        .containsExactly(mockOotdDto1, mockOotdDto2);
+  }
+
+  @Test
+  @DisplayName("feedId를 받았을 때, OOTD가 없을 때 빈 리스트를 응답한다.")
+  void findOotd_no_content() {
+    // given
+    given(ootdRepository.findByFeedId(feedId)).willReturn(List.of());
+
+    // when
+    List<OotdDto> result = ootdService.findOotdByFeedId(feedId);
+
+    // then
+    then(ootdRepository).should(times(1)).findByFeedId(feedId);
+    then(ootdMapper).shouldHaveNoInteractions();
+
+    assertThat(result)
+        .isNotNull()
+        .isEmpty();
+  }
+
 
 }

--- a/src/test/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImplTest.java
@@ -78,7 +78,7 @@ class OotdServiceImplTest {
         .attributes(null)
         .build();
     mockOotd2 = mock(Ootd.class);
-    mockOotdDto1 = OotdDto.builder()
+    mockOotdDto2 = OotdDto.builder()
         .clothesId(clothId2)
         .name("cloth2")
         .imageUrl(null)

--- a/src/test/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImplTest.java
@@ -1,0 +1,164 @@
+package com.codeit.weatherwear.domain.ootd.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.location.entity.Location;
+import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
+import com.codeit.weatherwear.domain.ootd.entity.Ootd;
+import com.codeit.weatherwear.domain.ootd.mapper.OotdMapper;
+import com.codeit.weatherwear.domain.ootd.repository.OotdRepository;
+import com.codeit.weatherwear.domain.user.entity.Gender;
+import com.codeit.weatherwear.domain.user.entity.Role;
+import com.codeit.weatherwear.domain.user.entity.User;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class OotdServiceImplTest {
+
+  @Mock
+  private OotdRepository ootdRepository;
+
+  @Mock
+  private OotdMapper ootdMapper;
+
+  @InjectMocks
+  private OotdServiceImpl ootdService;
+
+  private Feed mockFeed;
+
+  private List<UUID> clothIds;
+  private UUID clothId1;
+  private UUID clothId2;
+
+  private Ootd mockOotd1;
+  private OotdDto mockOotdDto1;
+  private Ootd mockOotd2;
+  private OotdDto mockOotdDto2;
+
+  private UUID authorId;
+  private String mockContent;
+
+  private Location mockLocation;
+  private User mockAuthor;
+  private UUID feedId;
+
+  @BeforeEach
+  void setUp() {
+
+    clothId1 = UUID.randomUUID();
+    clothId2 = UUID.randomUUID();
+    clothIds = List.of(clothId1, clothId2);
+
+    mockOotd1 = mock(Ootd.class);
+    mockOotdDto1 = OotdDto.builder()
+        .clothesId(clothId1)
+        .name("cloth1")
+        .imageUrl(null)
+        .type("상의")
+        .attributes(null)
+        .build();
+    mockOotd2 = mock(Ootd.class);
+    mockOotdDto1 = OotdDto.builder()
+        .clothesId(clothId2)
+        .name("cloth2")
+        .imageUrl(null)
+        .type("하의")
+        .attributes(null)
+        .build();
+
+    mockLocation = new Location(37.513068, 127.102570, 961159, 1953082, "서울 송파구 신천동");
+
+    authorId = UUID.randomUUID();
+    mockAuthor = User.builder()
+        .id(authorId)
+        .email("test@example.com")
+        .name("홍길동")
+        .password("!password1234")
+        .role(Role.USER)
+        .locked(false)
+        .gender(Gender.FEMALE)
+        .birthDate(LocalDate.of(2000, 1, 1))
+        .temperatureSensitivity(10)
+        .profileImageUrl(null)
+        .location(mockLocation)
+        .createdAt(Instant.now())
+        .updatedAt(Instant.now())
+        .build();
+
+    mockContent = "Mock Feed Content";
+
+    feedId = UUID.randomUUID();
+    mockFeed = Feed.builder()
+        .author(mockAuthor)
+        .content(mockContent)
+        .commentCount(0)
+        .likeCount(0)
+        .build();
+    ReflectionTestUtils.setField(mockFeed, "id", feedId);
+
+  }
+
+  @Test
+  @DisplayName("전달받은 Feed 객체와 clothIds를 통해 Ootd 등록을 성공한다.")
+  void createOotd_success() {
+    // given
+    given(ootdMapper.toEntity(mockFeed, clothId1)).willReturn(mockOotd1);
+    given(ootdMapper.toEntity(mockFeed, clothId2)).willReturn(mockOotd2);
+    given(ootdRepository.saveAll(List.of(mockOotd1, mockOotd2))).willReturn(
+        List.of(mockOotd1, mockOotd2));
+    given(ootdMapper.toDto(mockOotd1)).willReturn(mockOotdDto1);
+    given(ootdMapper.toDto(mockOotd2)).willReturn(mockOotdDto2);
+
+    // when
+    List<OotdDto> result = ootdService.createOotdList(mockFeed, clothIds);
+
+    // then
+    then(ootdMapper).should().toEntity(mockFeed, clothId1);
+    then(ootdMapper).should().toEntity(mockFeed, clothId2);
+    then(ootdRepository).should().saveAll(List.of(mockOotd1, mockOotd2));
+    then(ootdMapper).should(times(1)).toDto(mockOotd1);
+    then(ootdMapper).should(times(1)).toDto(mockOotd2);
+
+    assertThat(result)
+        .hasSize(2)
+        .containsExactly(mockOotdDto1, mockOotdDto2);
+
+  }
+
+  @Test
+  @DisplayName("전달받은 clothIds가 빈 리스트이다.")
+  void createOotd_no_content() {
+    // given
+    List<UUID> noClotheIds = List.of();
+
+    // when
+    List<OotdDto> result = ootdService.createOotdList(mockFeed, noClotheIds);
+
+    // then
+    then(ootdMapper).shouldHaveNoInteractions();
+    then(ootdRepository).shouldHaveNoInteractions();
+
+    assertThat(result)
+        .isNotNull()
+        .isEmpty();
+  }
+
+}

--- a/src/test/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/ootd/service/impl/OotdServiceImplTest.java
@@ -3,6 +3,7 @@ package com.codeit.weatherwear.domain.ootd.service.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
@@ -201,5 +202,27 @@ class OotdServiceImplTest {
         .isEmpty();
   }
 
+  @Test
+  @DisplayName("feedId를 받아 해당 OOTD들을 삭제한다")
+  void deleteOotd_success() {
+    // given
+    given(ootdRepository.findByFeedId(feedId)).willReturn(ootdList);
+    willDoNothing().given(ootdRepository).deleteAll(ootdList);
+    given(ootdMapper.toDto(mockOotd1)).willReturn(mockOotdDto1);
+    given(ootdMapper.toDto(mockOotd2)).willReturn(mockOotdDto2);
+
+    // when
+    List<OotdDto> result = ootdService.deleteOotdByFeedId(feedId);
+
+    // then
+    then(ootdRepository).should(times(1)).findByFeedId(feedId);
+    then(ootdRepository).should(times(1)).deleteAll(ootdList);
+    then(ootdMapper).should(times(1)).toDto(mockOotd1);
+    then(ootdMapper).should(times(1)).toDto(mockOotd2);
+
+    assertThat(result)
+        .hasSize(2)
+        .containsExactly(mockOotdDto1, mockOotdDto2);
+  }
 
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#55 #37 #38 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [x] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

feat/55/ootd-crud -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

OOTD 서비스 로직 기본 기능을 구현했습니다.

해당 OOTD의 경우, Feed에 종속적인 엔티티입니다. (외부에서 요청할 수 없음)
단위 테스트 코드는 작성하였지만,
이후 진행할 Feed API 리팩토링 및 페이지네이션 구현에서 Feed API와 함께 잘 작동되는지 확인 할 예정입니다.

또한, Clothes의 경우, 현재 작성 중에 있는 것으로 알고 있어 추후 Clothes 엔티티가 들어오게 되면 그 때 수정할 예정입니다.
(관련 부분은 코드 내 todo: 주석으로 작성해 두었으니 참고해주시면 됩니다)

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

push 이후 `./gradlew clean test`, `./gradlew clean build` 를 한 번씩 진행하는데, 모두 성공하였습니다.

![image](https://github.com/user-attachments/assets/a798984d-80bd-4b57-bc20-0faa99ef5f31)

![image](https://github.com/user-attachments/assets/85c5e1f4-4e17-425c-9894-fa7a887fa692)

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.