### PR TITLE
Feat: Notification CRUD

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/follow/FollowService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/follow/FollowService.java
@@ -76,6 +76,7 @@ public class FollowService {
     UUID nextIdAfter = null;
 
     if (hasNext) {
+      follows.remove(follows.size() - 1);
       FollowDto followDto = follows.get(follows.size() - 1);
 
       nextCursor = followDto.createdAt();

--- a/src/main/java/com/codeit/weatherwear/domain/follow/FollowService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/follow/FollowService.java
@@ -64,28 +64,27 @@ public class FollowService {
   public PageResponse<FollowDto> getFollowers(UUID followeeId, String cursor,
       UUID idAfter, int limit, String nameLike
   ) {
-    List<FollowDto> followings = followRepository
+    List<FollowDto> followers = followRepository
         .getFollowers(followeeId, cursor, idAfter, limit, nameLike);
     long totalCount = followRepository.countByFollowee_Id(followeeId);
-    return toPageResponse(followings, limit, totalCount);
+    return toPageResponse(followers, limit, totalCount);
   }
 
-  private PageResponse<FollowDto> toPageResponse(List<FollowDto> followings, int limit, long totalCount) {
-    boolean hasNext = followings.size() > limit;
+  private PageResponse<FollowDto> toPageResponse(List<FollowDto> follows, int limit, long totalCount) {
+    boolean hasNext = follows.size() > limit;
     Instant nextCursor = null;
     UUID nextIdAfter = null;
 
     if (hasNext) {
-      followings.remove(followings.size() - 1);
-      FollowDto followDto = followings.get(followings.size() - 1);
+      FollowDto followDto = follows.get(follows.size() - 1);
 
-      nextCursor = followDto.created();
+      nextCursor = followDto.createdAt();
       nextIdAfter = followDto.id();
     }
     String sortBy = "createdAt";
 
     return new PageResponse<>(
-        followings,
+        follows,
         nextCursor,
         nextIdAfter,
         hasNext,

--- a/src/main/java/com/codeit/weatherwear/domain/follow/dto/FollowDto.java
+++ b/src/main/java/com/codeit/weatherwear/domain/follow/dto/FollowDto.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 
 public record FollowDto(
     UUID id,
-    Instant created,
+    Instant createdAt,
     UserSummaryDto followee,
     UserSummaryDto follower
 ) {

--- a/src/main/java/com/codeit/weatherwear/domain/follow/repository/FollowRepositoryImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/follow/repository/FollowRepositoryImpl.java
@@ -67,7 +67,7 @@ public class FollowRepositoryImpl implements FollowRepositoryCustom {
   public List<FollowDto> getFollowings(UUID followerId, String cursor,
       UUID idAfter, int limit, String nameLike
   ) {
-    List<FollowDto> fetch = queryFactory
+    return queryFactory
         .select(Projections.constructor(FollowDto.class,
             follow.id,
             follow.createdAt,
@@ -94,18 +94,13 @@ public class FollowRepositoryImpl implements FollowRepositoryCustom {
         )
         .limit(limit + 1)
         .fetch();
-
-    if (fetch.size() > limit) {
-      fetch.remove(fetch.size() - 1);
-    }
-    return fetch;
   }
 
   @Override
   public List<FollowDto> getFollowers(UUID followeeId, String cursor,
       UUID idAfter, int limit, String nameLike
   ) {
-    List<FollowDto> fetch = queryFactory
+    return queryFactory
         .select(Projections.constructor(FollowDto.class,
             follow.id,
             follow.createdAt,
@@ -132,11 +127,6 @@ public class FollowRepositoryImpl implements FollowRepositoryCustom {
         )
         .limit(limit + 1)
         .fetch();
-
-    if (fetch.size() > limit) {
-      fetch.remove(fetch.size() - 1);
-    }
-    return fetch;
   }
 
   private BooleanExpression followerNameLike(String nameLike) {

--- a/src/main/java/com/codeit/weatherwear/domain/follow/repository/FollowRepositoryImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/follow/repository/FollowRepositoryImpl.java
@@ -67,7 +67,7 @@ public class FollowRepositoryImpl implements FollowRepositoryCustom {
   public List<FollowDto> getFollowings(UUID followerId, String cursor,
       UUID idAfter, int limit, String nameLike
   ) {
-    return queryFactory
+    List<FollowDto> fetch = queryFactory
         .select(Projections.constructor(FollowDto.class,
             follow.id,
             follow.createdAt,
@@ -94,13 +94,18 @@ public class FollowRepositoryImpl implements FollowRepositoryCustom {
         )
         .limit(limit + 1)
         .fetch();
+
+    if (fetch.size() > limit) {
+      fetch.remove(fetch.size() - 1);
+    }
+    return fetch;
   }
 
   @Override
   public List<FollowDto> getFollowers(UUID followeeId, String cursor,
       UUID idAfter, int limit, String nameLike
   ) {
-    return queryFactory
+    List<FollowDto> fetch = queryFactory
         .select(Projections.constructor(FollowDto.class,
             follow.id,
             follow.createdAt,
@@ -127,6 +132,11 @@ public class FollowRepositoryImpl implements FollowRepositoryCustom {
         )
         .limit(limit + 1)
         .fetch();
+
+    if (fetch.size() > limit) {
+      fetch.remove(fetch.size() - 1);
+    }
+    return fetch;
   }
 
   private BooleanExpression followerNameLike(String nameLike) {

--- a/src/main/java/com/codeit/weatherwear/domain/notification/Notification.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/Notification.java
@@ -3,12 +3,15 @@ package com.codeit.weatherwear.domain.notification;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -38,13 +41,28 @@ public class Notification {
   @Column(nullable = false)
   private String content;
 
-  private Notification(UUID receiverId, String title, String content) {
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private Level level;
+
+  public enum Level {
+    INFO, WARNING, ERROR;
+  }
+
+  @Builder
+  private Notification(UUID receiverId, String title, String content, Level level) {
     this.receiverId = receiverId;
     this.title = title;
     this.content = content;
+    this.level = level;
   }
 
-  public static Notification create(UUID receiverId, String title, String content) {
-    return new Notification(receiverId, title, content);
+  public static Notification create(UUID receiverId, String title, String content, Level level) {
+    return Notification.builder()
+        .receiverId(receiverId)
+        .title(title)
+        .content(content)
+        .level(level)
+        .build();
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/notification/Notification.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/Notification.java
@@ -49,7 +49,7 @@ public class Notification {
     INFO, WARNING, ERROR;
   }
 
-  @Builder
+  @Builder(access = AccessLevel.PROTECTED)
   private Notification(UUID receiverId, String title, String content, Level level) {
     this.receiverId = receiverId;
     this.title = title;

--- a/src/main/java/com/codeit/weatherwear/domain/notification/NotificationController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/NotificationController.java
@@ -1,0 +1,37 @@
+package com.codeit.weatherwear.domain.notification;
+
+import com.codeit.weatherwear.global.response.PageResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  @GetMapping
+  public ResponseEntity<PageResponse<NotificationDto>> getNotifications(
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) UUID idAfter,
+      @RequestParam int limit
+  ) {
+    //인증 기능이 완료되면 유저의 id를 가져오는 것으로 변경
+    UUID tempId = UUID.randomUUID();
+    return ResponseEntity.ok(notificationService.findNotification(tempId, cursor, idAfter, limit));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteNotification(@PathVariable UUID id) {
+    notificationService.delete(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/notification/NotificationDto.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/NotificationDto.java
@@ -1,0 +1,25 @@
+package com.codeit.weatherwear.domain.notification;
+
+import com.codeit.weatherwear.domain.notification.Notification.Level;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationDto(
+    UUID id,
+    Instant createdAt,
+    UUID receiverId,
+    String title,
+    String content,
+    Level level
+) {
+  public static NotificationDto from(Notification notification) {
+    return new NotificationDto(
+        notification.getId(),
+        notification.getCreatedAt(),
+        notification.getReceiverId(),
+        notification.getTitle(),
+        notification.getContent(),
+        notification.getLevel()
+    );
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/notification/NotificationRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/NotificationRepository.java
@@ -1,8 +1,0 @@
-package com.codeit.weatherwear.domain.notification;
-
-import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface NotificationRepository extends JpaRepository<Notification, UUID> {
-
-}

--- a/src/main/java/com/codeit/weatherwear/domain/notification/NotificationService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/NotificationService.java
@@ -1,0 +1,76 @@
+package com.codeit.weatherwear.domain.notification;
+
+import com.codeit.weatherwear.domain.notification.Notification.Level;
+import com.codeit.weatherwear.domain.notification.repository.NotificationRepository;
+import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
+import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.request.SortDirection;
+import com.codeit.weatherwear.global.response.PageResponse;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public NotificationDto create(UUID receiverId, String title, String content, Level level) {
+    if (!userRepository.existsById(receiverId)) {
+      throw new UserNotFoundException();
+    }
+
+    Notification notification = notificationRepository
+        .save(Notification.create(receiverId, title, content, level));
+    log.info("알림 생성. id={}", notification.getId());
+    return NotificationDto.from(notification);
+  }
+
+  public PageResponse<NotificationDto> findNotification(UUID receiverId, String cursor, UUID idAfter, int limit) {
+    List<NotificationDto> dtos = notificationRepository
+        .findNotification(receiverId, cursor, idAfter, limit);
+    long totalCount = notificationRepository.countByReceiverId(receiverId);
+    return toPageResponse(dtos, limit, totalCount);
+  }
+
+  @Transactional
+  public void delete(UUID id) {
+    notificationRepository.findById(id).ifPresent(notification -> {
+      notificationRepository.delete(notification);
+      log.info("알림 삭제. id={}", id);
+    });
+  }
+
+  private PageResponse<NotificationDto> toPageResponse(List<NotificationDto> notifications, int limit, long totalCount) {
+    boolean hasNext = notifications.size() > limit;
+    Instant nextCursor = null;
+    UUID nextIdAfter = null;
+
+    if (hasNext) {
+      NotificationDto notification = notifications.get(notifications.size() - 1);
+
+      nextCursor = notification.createdAt();
+      nextIdAfter = notification.id();
+    }
+    String sortBy = "createdAt";
+
+    return new PageResponse<>(
+        notifications,
+        nextCursor,
+        nextIdAfter,
+        hasNext,
+        totalCount,
+        sortBy,
+        SortDirection.DESCENDING.name()
+    );
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/notification/NotificationService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/NotificationService.java
@@ -56,6 +56,7 @@ public class NotificationService {
     UUID nextIdAfter = null;
 
     if (hasNext) {
+      notifications.remove(notifications.size() - 1);
       NotificationDto notification = notifications.get(notifications.size() - 1);
 
       nextCursor = notification.createdAt();

--- a/src/main/java/com/codeit/weatherwear/domain/notification/repository/NotificationCustomRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/repository/NotificationCustomRepository.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.domain.notification.repository;
+
+import com.codeit.weatherwear.domain.notification.NotificationDto;
+import java.util.List;
+import java.util.UUID;
+
+public interface NotificationCustomRepository {
+
+  List<NotificationDto> findNotification(UUID receiverId, String cursor, UUID idAfter, int limit);
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/notification/repository/NotificationCustomRepositoryImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/repository/NotificationCustomRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.codeit.weatherwear.domain.notification.repository;
+
+import static com.codeit.weatherwear.domain.follow.QFollow.follow;
+import static com.codeit.weatherwear.domain.notification.QNotification.notification;
+
+import com.codeit.weatherwear.domain.notification.NotificationDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class NotificationCustomRepositoryImpl implements NotificationCustomRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<NotificationDto> findNotification(UUID receiverId, String cursor, UUID idAfter,
+      int limit) {
+    List<NotificationDto> fetch = queryFactory
+        .select(Projections.constructor(NotificationDto.class,
+            notification.id, notification.createdAt, notification.receiverId,
+            notification.title, notification.content, notification.level)
+        )
+        .from(notification)
+        .where(
+            notification.receiverId.eq(receiverId),
+            cursor(cursor, idAfter)
+        )
+        .orderBy(
+            notification.createdAt.desc(),
+            notification.id.desc()
+        )
+        .limit(limit + 1)
+        .fetch();
+
+    if (fetch.size() > limit) {
+      fetch.remove(fetch.size() - 1);
+    }
+
+    return fetch;
+  }
+
+  private BooleanExpression cursor(String cursor, UUID idAfter) {
+    if (cursor == null || idAfter == null) {
+      return null;
+    }
+
+    Instant createdAtCursor = Instant.parse(cursor);
+    return follow.createdAt.lt(createdAtCursor)
+        .or(follow.createdAt.eq(createdAtCursor).and(follow.id.lt(idAfter)));
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/notification/repository/NotificationCustomRepositoryImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/repository/NotificationCustomRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.codeit.weatherwear.domain.notification.repository;
 
-import static com.codeit.weatherwear.domain.follow.QFollow.follow;
 import static com.codeit.weatherwear.domain.notification.QNotification.notification;
 
 import com.codeit.weatherwear.domain.notification.NotificationDto;
@@ -50,7 +49,7 @@ public class NotificationCustomRepositoryImpl implements NotificationCustomRepos
     }
 
     Instant createdAtCursor = Instant.parse(cursor);
-    return follow.createdAt.lt(createdAtCursor)
-        .or(follow.createdAt.eq(createdAtCursor).and(follow.id.lt(idAfter)));
+    return notification.createdAt.lt(createdAtCursor)
+        .or(notification.createdAt.eq(createdAtCursor).and(notification.id.lt(idAfter)));
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/notification/repository/NotificationCustomRepositoryImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/repository/NotificationCustomRepositoryImpl.java
@@ -19,7 +19,7 @@ public class NotificationCustomRepositoryImpl implements NotificationCustomRepos
   @Override
   public List<NotificationDto> findNotification(UUID receiverId, String cursor, UUID idAfter,
       int limit) {
-    List<NotificationDto> fetch = queryFactory
+    return queryFactory
         .select(Projections.constructor(NotificationDto.class,
             notification.id, notification.createdAt, notification.receiverId,
             notification.title, notification.content, notification.level)
@@ -35,12 +35,6 @@ public class NotificationCustomRepositoryImpl implements NotificationCustomRepos
         )
         .limit(limit + 1)
         .fetch();
-
-    if (fetch.size() > limit) {
-      fetch.remove(fetch.size() - 1);
-    }
-
-    return fetch;
   }
 
   private BooleanExpression cursor(String cursor, UUID idAfter) {

--- a/src/main/java/com/codeit/weatherwear/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.codeit.weatherwear.domain.notification.repository;
+
+import com.codeit.weatherwear.domain.notification.Notification;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID>, NotificationCustomRepository {
+
+  long countByReceiverId(UUID receiverId);
+}

--- a/src/test/java/com/codeit/weatherwear/domain/notification/NotificationRepositoryTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/notification/NotificationRepositoryTest.java
@@ -1,0 +1,131 @@
+package com.codeit.weatherwear.domain.notification;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.codeit.weatherwear.domain.notification.Notification.Level;
+import com.codeit.weatherwear.domain.notification.repository.NotificationRepository;
+import com.codeit.weatherwear.domain.user.entity.User;
+import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.config.JpaConfig;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import(JpaConfig.class)
+class NotificationRepositoryTest {
+
+  @Autowired
+  NotificationRepository notificationRepository;
+
+  @Autowired
+  UserRepository userRepository;
+
+  User alice;
+  User bob;
+
+  Notification notification1;
+  Notification notification2;
+  Notification notification3;
+  Notification notification4;
+  Notification notification5;
+
+  @BeforeEach
+  void setUp() throws InterruptedException {
+    alice = User.builder()
+        .email("alice@test.com")
+        .name("alice")
+        .password("alice1234")
+        .build();
+
+    bob = User.builder()
+        .email("bob@test.com")
+        .name("bob")
+        .password("bob1234")
+        .build();
+
+    userRepository.save(alice);
+    userRepository.save(bob);
+
+    notification1 = Notification
+        .create(alice.getId(), "피드 작성", "bob이 피드를 작성했습니다.", Level.INFO);
+    notification2 = Notification
+        .create(bob.getId(), "의상 속성 변경", "내 의상의 속성이 변경되었습니다.", Level.INFO);
+    notification3 = Notification
+        .create(alice.getId(), "의상 속성 추가", "내 의상에 속성이 추가되었습니다.", Level.INFO);
+    notification4 = Notification
+        .create(alice.getId(), "피드 작성", "charlie가 피드를 작성했습니다.", Level.INFO);
+    notification5 = Notification
+        .create(alice.getId(), "의상 속성 변경", "내 의상의 속성이 변경되었습니다.", Level.INFO);
+
+
+    notificationRepository.save(notification1);
+    Thread.sleep(1);
+    notificationRepository.save(notification2);
+    Thread.sleep(1);
+    notificationRepository.save(notification3);
+    Thread.sleep(1);
+    notificationRepository.save(notification4);
+    Thread.sleep(1);
+    notificationRepository.save(notification5);
+  }
+
+  @Test
+  @DisplayName("알림 조회")
+  void find() {
+    int limit = 20;
+    List<NotificationDto> notifications = notificationRepository
+        .findNotification(alice.getId(), null, null, limit);
+
+    assertThat(notifications)
+        .hasSize(4)
+        .allSatisfy(notification -> assertThat(notification.receiverId()).isEqualTo(alice.getId()))
+        .satisfiesExactly(
+            notification -> assertThat(notification.id()).isEqualTo(notification5.getId()),
+            notification -> assertThat(notification.id()).isEqualTo(notification4.getId()),
+            notification -> assertThat(notification.id()).isEqualTo(notification3.getId()),
+            notification -> assertThat(notification.id()).isEqualTo(notification1.getId())
+        );
+  }
+
+  @Test
+  @DisplayName("알림 조회 - hasNext true인 경우")
+  void hasNext() {
+    int limit = 2;
+    List<NotificationDto> notifications = notificationRepository
+        .findNotification(alice.getId(), null, null, limit);
+
+    assertThat(notifications)
+        .hasSize(2)
+        .allSatisfy(notification -> assertThat(notification.receiverId()).isEqualTo(alice.getId()))
+        .satisfiesExactly(
+            notification -> assertThat(notification.id()).isEqualTo(notification5.getId()),
+            notification -> assertThat(notification.id()).isEqualTo(notification4.getId())
+        );
+  }
+
+  @Test
+  @DisplayName("알림 조회 - 커서가 있는 경우")
+  void findWithCursor() {
+    int limit = 2;
+    Instant cursor = notification4.getCreatedAt().truncatedTo(ChronoUnit.MICROS);
+    List<NotificationDto> notifications = notificationRepository
+        .findNotification(alice.getId(), cursor.toString(), notification4.getId(), limit);
+
+    assertThat(notifications)
+        .hasSize(2)
+        .allSatisfy(notification -> assertThat(notification.receiverId()).isEqualTo(alice.getId()))
+        .satisfiesExactly(
+            notification -> assertThat(notification.id()).isEqualTo(notification3.getId()),
+            notification -> assertThat(notification.id()).isEqualTo(notification1.getId())
+        );
+  }
+}

--- a/src/test/java/com/codeit/weatherwear/domain/notification/NotificationRepositoryTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/notification/NotificationRepositoryTest.java
@@ -104,7 +104,7 @@ class NotificationRepositoryTest {
         .findNotification(alice.getId(), null, null, limit);
 
     assertThat(notifications)
-        .hasSize(2)
+        .hasSize(3)
         .allSatisfy(notification -> assertThat(notification.receiverId()).isEqualTo(alice.getId()))
         .satisfiesExactly(
             notification -> assertThat(notification.id()).isEqualTo(notification5.getId()),

--- a/src/test/java/com/codeit/weatherwear/domain/notification/NotificationRepositoryTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/notification/NotificationRepositoryTest.java
@@ -108,7 +108,8 @@ class NotificationRepositoryTest {
         .allSatisfy(notification -> assertThat(notification.receiverId()).isEqualTo(alice.getId()))
         .satisfiesExactly(
             notification -> assertThat(notification.id()).isEqualTo(notification5.getId()),
-            notification -> assertThat(notification.id()).isEqualTo(notification4.getId())
+            notification -> assertThat(notification.id()).isEqualTo(notification4.getId()),
+            notification -> assertThat(notification.id()).isEqualTo(notification3.getId())
         );
   }
 

--- a/src/test/java/com/codeit/weatherwear/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/notification/NotificationServiceTest.java
@@ -1,0 +1,95 @@
+package com.codeit.weatherwear.domain.notification;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.codeit.weatherwear.domain.notification.Notification.Level;
+import com.codeit.weatherwear.domain.notification.repository.NotificationRepository;
+import com.codeit.weatherwear.domain.user.entity.User;
+import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
+import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+  @Mock
+  NotificationRepository notificationRepository;
+
+  @Mock
+  UserRepository userRepository;
+
+  @InjectMocks
+  NotificationService notificationService;
+
+  User alice;
+  User bob;
+
+  String title = "test";
+  String content = "test1234";
+
+  @BeforeEach
+  void setUp() {
+    alice = User.builder()
+        .email("alice@aaa.com")
+        .name("alice")
+        .password("alice123")
+        .build();
+    bob = User.builder()
+        .email("bob@bbb.com")
+        .name("bob")
+        .password("bob123")
+        .build();
+
+    ReflectionTestUtils.setField(alice, "id", UUID.randomUUID());
+    ReflectionTestUtils.setField(bob, "id", UUID.randomUUID());
+  }
+
+  @Test
+  @DisplayName("생성 성공")
+  void create() {
+    given(userRepository.existsById(alice.getId())).willReturn(true);
+    given(notificationRepository.save(any())).willAnswer(invocation -> {
+      Notification notification = invocation.getArgument(0);
+      ReflectionTestUtils.setField(notification, "id", UUID.randomUUID());
+      ReflectionTestUtils.setField(notification, "createdAt", Instant.now());
+      return notification;
+    });
+
+    NotificationDto notification = notificationService
+        .create(alice.getId(), title, content, Level.INFO);
+
+    assertThat(notification.receiverId()).isEqualTo(alice.getId());
+    assertThat(notification.title()).isEqualTo(title);
+    assertThat(notification.content()).isEqualTo(content);
+    assertThat(notification.level()).isEqualTo(Level.INFO);
+
+    then(userRepository).should().existsById(alice.getId());
+    then(notificationRepository).should().save(any());
+  }
+
+  @Test
+  @DisplayName("유저가 존재하지 않으면 알림 생성 실패")
+  void noUser() {
+    given(userRepository.existsById(alice.getId())).willReturn(false);
+
+    assertThatThrownBy(() -> notificationService.create(alice.getId(), title, content, Level.INFO))
+        .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage())
+        .isInstanceOf(UserNotFoundException.class);
+
+    then(userRepository).should().existsById(alice.getId());
+    then(notificationRepository).shouldHaveNoInteractions();
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈
- #74 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
feat/74/notification-crud -> dev

### 📑 변경 사항
- Notification 엔티티에 level 속성을 추가했습니다.
- Notification 조회, 삭제 api를 구현했습니다
- Notification 생성 로직을 구현했습니다.
- FollowDto의 created 필드를 createdAt으로 변경했습니다.
- 테스트 코드를 추가했습니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.