### PR TITLE
Feat: Feed 댓글 API 구현

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedCommentController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedCommentController.java
@@ -1,0 +1,43 @@
+package com.codeit.weatherwear.domain.feed.controller;
+
+import com.codeit.weatherwear.domain.feed.dto.request.FeedCommentCreateRequest;
+import com.codeit.weatherwear.domain.feed.dto.request.FeedCommentGetParamRequest;
+import com.codeit.weatherwear.domain.feed.dto.response.FeedCommentDto;
+import com.codeit.weatherwear.domain.feed.service.FeedCommentService;
+import com.codeit.weatherwear.global.response.PageResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/feeds/{feedId}/comments")
+@RequiredArgsConstructor
+public class FeedCommentController {
+
+  private final FeedCommentService feedCommentService;
+
+  @PostMapping
+  public ResponseEntity<FeedCommentDto> createFeedComment(
+      @PathVariable UUID feedId,
+      @RequestBody FeedCommentCreateRequest request
+  ) {
+    return ResponseEntity.ok(feedCommentService.createFeedComment(feedId, request));
+  }
+
+  @GetMapping
+  public ResponseEntity<PageResponse<FeedCommentDto>> getFeedComment(
+      @PathVariable UUID feedId,
+      @ModelAttribute @Valid FeedCommentGetParamRequest queryRequest
+  ) {
+    return ResponseEntity.ok(feedCommentService.getFeedComments(feedId, queryRequest));
+  }
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/dto/condition/FeedCommentSearchCondition.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/dto/condition/FeedCommentSearchCondition.java
@@ -1,0 +1,19 @@
+package com.codeit.weatherwear.domain.feed.dto.condition;
+
+import com.codeit.weatherwear.global.request.SortDirection;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FeedCommentSearchCondition {
+
+  private UUID feedId;
+  private String cursor;
+  private UUID idAfter;
+  private int limit;
+
+  private String sortBy;
+  private SortDirection sortDirection;
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/dto/request/FeedCommentCreateRequest.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/dto/request/FeedCommentCreateRequest.java
@@ -1,0 +1,21 @@
+package com.codeit.weatherwear.domain.feed.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FeedCommentCreateRequest {
+
+  @NotNull
+  private UUID feedId;
+
+  @NotNull
+  private UUID authorId;
+
+  @NotEmpty
+  private String content;
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/dto/request/FeedCommentGetParamRequest.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/dto/request/FeedCommentGetParamRequest.java
@@ -1,0 +1,35 @@
+package com.codeit.weatherwear.domain.feed.dto.request;
+
+import com.codeit.weatherwear.domain.feed.dto.condition.FeedCommentSearchCondition;
+import com.codeit.weatherwear.global.request.SortDirection;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FeedCommentGetParamRequest {
+
+  @NotNull(message = "대상 Feed Id는 필수입니다.")
+  private UUID feedId;
+
+  private String cursor;
+  private UUID idAfter;
+
+  @NotNull(message = "limit는 필수입니다.")
+  @Min(value = 1, message = "limit는 1 이상이어야 합니다.")
+  private Integer limit;
+
+  public FeedCommentSearchCondition toSearchCondition() {
+    return FeedCommentSearchCondition.builder()
+        .feedId(this.getFeedId())
+        .cursor(this.getCursor())
+        .idAfter(this.getIdAfter())
+        .limit(this.getLimit())
+        .sortBy("createdAt")
+        .sortDirection(SortDirection.DESCENDING)
+        .build();
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/dto/response/FeedCommentDto.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/dto/response/FeedCommentDto.java
@@ -1,0 +1,18 @@
+package com.codeit.weatherwear.domain.feed.dto.response;
+
+import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FeedCommentDto {
+
+  private UUID id;
+  private Instant createdAt;
+  private UUID feedId;
+  private UserSummaryDto author;
+  private String content;
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/mapper/FeedCommentMapper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/mapper/FeedCommentMapper.java
@@ -1,0 +1,33 @@
+package com.codeit.weatherwear.domain.feed.mapper;
+
+import com.codeit.weatherwear.domain.feed.dto.response.FeedCommentDto;
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.feed.entity.FeedComment;
+import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
+import com.codeit.weatherwear.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FeedCommentMapper {
+
+  public FeedComment toEntity(Feed feed, User author, String content) {
+    return FeedComment.builder()
+        .feed(feed)
+        .author(author)
+        .content(content)
+        .build();
+  }
+
+  public FeedCommentDto toDto(FeedComment feedComment, UserSummaryDto author) {
+    return FeedCommentDto.builder()
+        .id(feedComment.getId())
+        .createdAt(feedComment.getCreatedAt())
+        .feedId(feedComment.getFeed().getId())
+        .author(author)
+        .content(feedComment.getContent())
+        .build();
+  }
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/repository/FeedCommentCustomRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/repository/FeedCommentCustomRepository.java
@@ -1,0 +1,13 @@
+package com.codeit.weatherwear.domain.feed.repository;
+
+import com.codeit.weatherwear.domain.feed.dto.condition.FeedCommentSearchCondition;
+import com.codeit.weatherwear.domain.feed.entity.FeedComment;
+import java.util.UUID;
+import org.springframework.data.domain.Slice;
+
+public interface FeedCommentCustomRepository {
+
+  Slice<FeedComment> searchFeedComments(FeedCommentSearchCondition condition);
+
+  long getTotalFeedCommentCount(UUID feedId);
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/repository/FeedCommentRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/repository/FeedCommentRepository.java
@@ -1,11 +1,15 @@
 package com.codeit.weatherwear.domain.feed.repository;
 
+import com.codeit.weatherwear.domain.feed.entity.Feed;
 import com.codeit.weatherwear.domain.feed.entity.FeedComment;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FeedCommentRepository extends JpaRepository<FeedComment, UUID> {
+public interface FeedCommentRepository extends JpaRepository<FeedComment, UUID>,
+    FeedCommentCustomRepository {
 
+  List<FeedComment> findAllByFeed(Feed feed);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/feed/repository/impl/FeedCommentCustomRepositoryImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/repository/impl/FeedCommentCustomRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.codeit.weatherwear.domain.feed.repository.impl;
 
 import com.codeit.weatherwear.domain.feed.dto.condition.FeedCommentSearchCondition;
-import com.codeit.weatherwear.domain.feed.entity.Feed;
 import com.codeit.weatherwear.domain.feed.entity.FeedComment;
 import com.codeit.weatherwear.domain.feed.entity.QFeedComment;
 import com.codeit.weatherwear.domain.feed.exception.NotImplementSortFieldException;
@@ -108,7 +107,7 @@ public class FeedCommentCustomRepositoryImpl implements FeedCommentCustomReposit
       throw new UnsupportedSortFieldException(sortBy);
     }
 
-    PathBuilder<Feed> path = new PathBuilder<>(Feed.class, "feed");
+    PathBuilder<FeedComment> path = new PathBuilder<>(FeedComment.class, "feedComment");
     Order order = direction == SortDirection.ASCENDING ? Order.ASC : Order.DESC;
 
     OrderSpecifier<?> primarySort = switch (sortBy) {

--- a/src/main/java/com/codeit/weatherwear/domain/feed/repository/impl/FeedCommentCustomRepositoryImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/repository/impl/FeedCommentCustomRepositoryImpl.java
@@ -1,0 +1,128 @@
+package com.codeit.weatherwear.domain.feed.repository.impl;
+
+import com.codeit.weatherwear.domain.feed.dto.condition.FeedCommentSearchCondition;
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.feed.entity.FeedComment;
+import com.codeit.weatherwear.domain.feed.entity.QFeedComment;
+import com.codeit.weatherwear.domain.feed.exception.NotImplementSortFieldException;
+import com.codeit.weatherwear.domain.feed.exception.UnsupportedSortFieldException;
+import com.codeit.weatherwear.domain.feed.repository.FeedCommentCustomRepository;
+import com.codeit.weatherwear.domain.user.entity.QUser;
+import com.codeit.weatherwear.global.request.SortDirection;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@Slf4j
+@RequiredArgsConstructor
+public class FeedCommentCustomRepositoryImpl implements FeedCommentCustomRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  private static final String SORT_BY_CREATED_AT = "createdAt";
+  private static final List<String> ALLOWED_SORT_FIELDS = List.of(SORT_BY_CREATED_AT);
+
+  @Override
+  public Slice<FeedComment> searchFeedComments(FeedCommentSearchCondition condition) {
+    QFeedComment feedComment = QFeedComment.feedComment;
+    int limit = condition.getLimit();
+
+    List<FeedComment> contents = queryFactory
+        .selectFrom(feedComment)
+        .join(feedComment.author, QUser.user).fetchJoin()
+        .where(
+            feedIdEqual(condition.getFeedId()),
+            idAfter(feedComment, condition.getIdAfter(), condition.getCursor(),
+                condition.getSortBy(), condition.getSortDirection())
+        )
+        .orderBy(sortBy(condition.getSortBy(), condition.getSortDirection()))
+        .limit(limit + 1)
+        .fetch();
+
+    boolean hasNext = contents.size() > limit;
+    if (hasNext) {
+      contents.remove(limit);
+    }
+
+    return new SliceImpl<>(contents, PageRequest.of(0, limit), hasNext);
+  }
+
+  @Override
+  public long getTotalFeedCommentCount(UUID feedId) {
+    QFeedComment feedComment = QFeedComment.feedComment;
+    Long result = queryFactory
+        .select(feedComment.count())
+        .from(feedComment)
+        .where(feedComment.feed.id.eq(feedId))
+        .fetchOne();
+
+    return result != null ? result : 0L;
+  }
+
+  private BooleanExpression feedIdEqual(UUID feedId) {
+    return feedId != null ? QFeedComment.feedComment.feed.id.eq(feedId) : null;
+  }
+
+  private BooleanExpression idAfter(QFeedComment feedComment, UUID idAfter, String cursor,
+      String sortBy,
+      SortDirection direction) {
+
+    if (idAfter == null || cursor == null) {
+      return null;
+    }
+
+    switch (sortBy) {
+      case SORT_BY_CREATED_AT -> {
+        Instant cursorCreatedAt = Instant.parse(cursor);
+        DateTimeExpression<Instant> createdAt = feedComment.createdAt;
+        if (direction == SortDirection.ASCENDING) {
+          return createdAt.gt(cursorCreatedAt)
+              .or(createdAt.eq(cursorCreatedAt).and(feedComment.id.gt(idAfter)));
+        } else {
+          return createdAt.lt(cursorCreatedAt)
+              .or(createdAt.eq(cursorCreatedAt).and(feedComment.id.lt(idAfter)));
+        }
+      }
+      default -> {
+        log.warn("Not Implement Sort Field in Feed Comment: {}", sortBy);
+        throw new NotImplementSortFieldException(sortBy);
+      }
+    }
+  }
+
+  private OrderSpecifier<?>[] sortBy(String sortBy, SortDirection direction) {
+
+    if (!ALLOWED_SORT_FIELDS.contains(sortBy)) {
+      log.warn("Unsupported Sort Field in Feed Comment: {}", sortBy);
+      throw new UnsupportedSortFieldException(sortBy);
+    }
+
+    PathBuilder<Feed> path = new PathBuilder<>(Feed.class, "feed");
+    Order order = direction == SortDirection.ASCENDING ? Order.ASC : Order.DESC;
+
+    OrderSpecifier<?> primarySort = switch (sortBy) {
+      case SORT_BY_CREATED_AT ->
+          new OrderSpecifier<>(order, path.getDateTime(SORT_BY_CREATED_AT, Instant.class));
+      default -> {
+        log.warn("Not Implement Sort Field in Feed Comment: {}", sortBy);
+        throw new NotImplementSortFieldException(sortBy);
+      }
+    };
+
+    OrderSpecifier<UUID> secondarySort = new OrderSpecifier<>(order, path.get("id", UUID.class));
+
+    return new OrderSpecifier<?>[]{primarySort, secondarySort};
+  }
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/FeedCommentService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/FeedCommentService.java
@@ -1,0 +1,19 @@
+package com.codeit.weatherwear.domain.feed.service;
+
+import com.codeit.weatherwear.domain.feed.dto.request.FeedCommentCreateRequest;
+import com.codeit.weatherwear.domain.feed.dto.request.FeedCommentGetParamRequest;
+import com.codeit.weatherwear.domain.feed.dto.response.FeedCommentDto;
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.global.response.PageResponse;
+import java.util.UUID;
+
+public interface FeedCommentService {
+
+  FeedCommentDto createFeedComment(UUID feedId, FeedCommentCreateRequest request);
+
+  PageResponse<FeedCommentDto> getFeedComments(UUID feedId,
+      FeedCommentGetParamRequest queryRequest);
+
+  void deleteFeedCommentsByFeed(Feed feed);
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImpl.java
@@ -1,0 +1,117 @@
+package com.codeit.weatherwear.domain.feed.service.impl;
+
+import com.codeit.weatherwear.domain.feed.dto.condition.FeedCommentSearchCondition;
+import com.codeit.weatherwear.domain.feed.dto.request.FeedCommentCreateRequest;
+import com.codeit.weatherwear.domain.feed.dto.request.FeedCommentGetParamRequest;
+import com.codeit.weatherwear.domain.feed.dto.response.FeedCommentDto;
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.feed.entity.FeedComment;
+import com.codeit.weatherwear.domain.feed.exception.FeedNotFoundException;
+import com.codeit.weatherwear.domain.feed.mapper.FeedCommentMapper;
+import com.codeit.weatherwear.domain.feed.repository.FeedCommentRepository;
+import com.codeit.weatherwear.domain.feed.repository.FeedRepository;
+import com.codeit.weatherwear.domain.feed.service.FeedCommentService;
+import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
+import com.codeit.weatherwear.domain.user.entity.User;
+import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
+import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.response.PageResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedCommentServiceImpl implements FeedCommentService {
+
+  private final FeedCommentRepository feedCommentRepository;
+  private final FeedRepository feedRepository;
+  private final UserRepository userRepository;
+
+  private final FeedCommentMapper feedCommentMapper;
+
+  @Transactional
+  @Override
+  public FeedCommentDto createFeedComment(UUID feedId, FeedCommentCreateRequest request) {
+    log.debug("Request Create Feed Comment - Feed: {}", feedId);
+    Feed feed = feedRepository.findById(feedId)
+        .orElseThrow(() -> new FeedNotFoundException(feedId));
+    User author = userRepository.findById(request.getAuthorId())
+        .orElseThrow(UserNotFoundException::new);
+
+    feed.increaseCommentCount();
+    FeedComment comment = feedCommentMapper.toEntity(feed, author, request.getContent());
+    FeedComment saved = feedCommentRepository.save(comment);
+
+    UserSummaryDto userSummary = UserSummaryDto.from(saved.getAuthor());
+    FeedCommentDto feedCommentDto = feedCommentMapper.toDto(saved, userSummary);
+    log.info("Create feed comment complete: {}", feedCommentDto.getId());
+    return feedCommentDto;
+  }
+
+  @Transactional(readOnly = true)
+  @Override
+  public PageResponse<FeedCommentDto> getFeedComments(UUID feedId,
+      FeedCommentGetParamRequest queryRequest) {
+    log.debug("Request Get Feed Comments - Feed: {}", feedId);
+    FeedCommentSearchCondition condition = queryRequest.toSearchCondition();
+    Slice<FeedComment> feedCommentSlice = feedCommentRepository.searchFeedComments(condition);
+    long totalCount = feedCommentRepository.getTotalFeedCommentCount(feedId);
+
+    return toPageResponse(feedCommentSlice, condition, totalCount);
+  }
+
+  @Transactional
+  @Override
+  public void deleteFeedCommentsByFeed(Feed feed) {
+    log.debug("Request Feed's all comment delete: {}", feed.getId());
+    List<FeedComment> feedCommentList = feedCommentRepository.findAllByFeed(feed);
+    feedCommentRepository.deleteAll(feedCommentList);
+    log.info("Delete all feed comments({}) in feed: {}", feedCommentList.size(), feed.getId());
+  }
+
+  private PageResponse<FeedCommentDto> toPageResponse(Slice<FeedComment> commentSlice,
+      FeedCommentSearchCondition condition, long totalCount) {
+
+    List<FeedComment> comments = commentSlice.getContent();
+
+    Map<UUID, UserSummaryDto> userSummaryMap = userRepository.findAllById(
+            comments.stream()
+                .map(comment -> comment.getAuthor().getId())
+                .collect(Collectors.toSet())
+        ).stream()
+        .collect(Collectors.toMap(User::getId, UserSummaryDto::from));
+
+    List<FeedCommentDto> data = comments.stream()
+        .map(comment -> {
+          UserSummaryDto userSummary = userSummaryMap.get(comment.getAuthor().getId());
+          return feedCommentMapper.toDto(comment, userSummary);
+        })
+        .toList();
+
+    UUID nextIdAfter = null;
+    Object nextCursor = null;
+    if (commentSlice.hasNext() && !data.isEmpty()) {
+      nextIdAfter = data.get(data.size() - 1).getId();
+      nextCursor = data.get(data.size() - 1).getCreatedAt();
+    }
+
+    return new PageResponse<>(
+        data,
+        nextCursor,
+        nextIdAfter,
+        commentSlice.hasNext(),
+        totalCount,
+        condition.getSortBy(),
+        condition.getSortDirection().name()
+    );
+  }
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImpl.java
@@ -99,8 +99,9 @@ public class FeedCommentServiceImpl implements FeedCommentService {
     UUID nextIdAfter = null;
     Object nextCursor = null;
     if (commentSlice.hasNext() && !data.isEmpty()) {
-      nextIdAfter = data.get(data.size() - 1).getId();
-      nextCursor = data.get(data.size() - 1).getCreatedAt();
+      FeedComment nextFirstItem = comments.get(comments.size() - 1);
+      nextIdAfter = nextFirstItem.getId();
+      nextCursor = nextFirstItem.getCreatedAt();
     }
 
     return new PageResponse<>(

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImpl.java
@@ -9,6 +9,7 @@ import com.codeit.weatherwear.domain.feed.entity.Feed;
 import com.codeit.weatherwear.domain.feed.exception.FeedNotFoundException;
 import com.codeit.weatherwear.domain.feed.mapper.FeedMapper;
 import com.codeit.weatherwear.domain.feed.repository.FeedRepository;
+import com.codeit.weatherwear.domain.feed.service.FeedCommentService;
 import com.codeit.weatherwear.domain.feed.service.FeedService;
 import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
 import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
@@ -39,6 +40,7 @@ public class FeedServiceImpl implements FeedService {
   private final FeedMapper feedMapper;
   private final FeedRepository feedRepository;
   private final OotdService ootdService;
+  private final FeedCommentService feedCommentService;
 
   @Transactional
   @Override
@@ -54,7 +56,7 @@ public class FeedServiceImpl implements FeedService {
     List<Feed> resultList = hasNext ? feedList.subList(0, condition.getLimit()) : feedList;
     List<FeedDto> feedDtoList = resultList.stream().map(this::toFeedDto)
         .collect(Collectors.toList());
-    
+
     return toPageResponse(feedDtoList, condition, hasNext);
   }
 
@@ -92,6 +94,7 @@ public class FeedServiceImpl implements FeedService {
 
     Feed feed = feedRepository.findById(feedId)
         .orElseThrow(() -> new FeedNotFoundException(feedId));
+    feedCommentService.deleteFeedCommentsByFeed(feed);
     feedRepository.delete(feed);
     List<OotdDto> ootds = ootdService.deleteOotdByFeedId(feedId);
 

--- a/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImplTest.java
@@ -1,0 +1,296 @@
+package com.codeit.weatherwear.domain.feed.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.codeit.weatherwear.domain.feed.dto.condition.FeedCommentSearchCondition;
+import com.codeit.weatherwear.domain.feed.dto.request.FeedCommentCreateRequest;
+import com.codeit.weatherwear.domain.feed.dto.request.FeedCommentGetParamRequest;
+import com.codeit.weatherwear.domain.feed.dto.response.FeedCommentDto;
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.feed.entity.FeedComment;
+import com.codeit.weatherwear.domain.feed.exception.FeedNotFoundException;
+import com.codeit.weatherwear.domain.feed.mapper.FeedCommentMapper;
+import com.codeit.weatherwear.domain.feed.repository.FeedCommentRepository;
+import com.codeit.weatherwear.domain.feed.repository.FeedRepository;
+import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
+import com.codeit.weatherwear.domain.location.entity.Location;
+import com.codeit.weatherwear.domain.user.entity.Gender;
+import com.codeit.weatherwear.domain.user.entity.Role;
+import com.codeit.weatherwear.domain.user.entity.User;
+import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
+import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.request.SortDirection;
+import com.codeit.weatherwear.global.response.PageResponse;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class FeedCommentServiceImplTest {
+
+  @InjectMocks
+  private FeedCommentServiceImpl feedCommentService;
+
+  @Mock
+  private FeedCommentRepository feedCommentRepository;
+  @Mock
+  private FeedRepository feedRepository;
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private FeedCommentMapper feedCommentMapper;
+
+  private FeedCommentCreateRequest createRequest;
+  private FeedCommentGetParamRequest getParamRequest;
+  private FeedCommentSearchCondition condition;
+
+  private Location mockLocation;
+  private UUID authorId;
+  private User author;
+  private UserSummaryDto authorDto;
+
+  private UUID feedId;
+  private Feed feed;
+  private long commentTotalCount;
+
+  private UUID commentId1, commentId2;
+  private Instant commentCreatedAt1, commentCreatedAt2;
+  private FeedComment comment1, comment2;
+  private String commentContent1, commentContent2;
+  private FeedCommentDto commentDto1, commentDto2;
+  private List<FeedComment> feedCommentList;
+  private Slice<FeedComment> commentSlice;
+
+  @BeforeEach
+  void setUp() {
+    mockLocation = mock(Location.class);
+
+    authorId = UUID.randomUUID();
+    feedId = UUID.randomUUID();
+
+    author = User.builder()
+        .id(authorId)
+        .email("test@example.com")
+        .name("홍길동")
+        .password("!password1234")
+        .role(Role.USER)
+        .locked(false)
+        .gender(Gender.FEMALE)
+        .birthDate(LocalDate.of(2000, 1, 1))
+        .temperatureSensitivity(10)
+        .profileImageUrl(null)
+        .location(mockLocation)
+        .createdAt(Instant.now())
+        .updatedAt(Instant.now())
+        .build();
+
+    authorDto = UserSummaryDto.from(author);
+
+    feed = Feed.builder()
+        .author(author)
+        .content("feed1")
+        .commentCount(0)
+        .likeCount(0)
+        .build();
+    ReflectionTestUtils.setField(feed, "id", feedId);
+
+    commentId1 = UUID.randomUUID();
+    commentContent1 = "comment1";
+    commentCreatedAt1 = Instant.now().minusSeconds(60);
+
+    commentId2 = UUID.randomUUID();
+    commentContent2 = "comment2";
+    commentCreatedAt2 = Instant.now().minusSeconds(30);
+
+    comment1 = FeedComment.builder()
+        .feed(feed)
+        .author(author)
+        .content(commentContent1)
+        .build();
+    ReflectionTestUtils.setField(comment1, "id", commentId1);
+    ReflectionTestUtils.setField(comment1, "createdAt", commentCreatedAt1);
+
+    comment2 = FeedComment.builder()
+        .feed(feed)
+        .author(author)
+        .content(commentContent2)
+        .build();
+    ReflectionTestUtils.setField(comment2, "id", commentId2);
+    ReflectionTestUtils.setField(comment2, "createdAt", commentCreatedAt2);
+
+    commentDto1 = FeedCommentDto.builder()
+        .id(commentId1)
+        .feedId(feedId)
+        .author(authorDto)
+        .content(commentContent1)
+        .createdAt(Instant.now())
+        .build();
+    commentDto2 = FeedCommentDto.builder()
+        .id(commentId2)
+        .feedId(feedId)
+        .author(authorDto)
+        .content(commentContent2)
+        .createdAt(Instant.now())
+        .build();
+  }
+
+  private FeedCommentCreateRequest createRequest(UUID authorId, UUID feedId, String content) {
+    return FeedCommentCreateRequest.builder()
+        .authorId(authorId)
+        .feedId(feedId)
+        .content(content)
+        .build();
+  }
+
+  private FeedCommentGetParamRequest createParamRequest(String cursor, UUID idAfter, int limit) {
+    return FeedCommentGetParamRequest.builder()
+        .feedId(feedId)
+        .cursor(cursor)
+        .idAfter(idAfter)
+        .limit(limit)
+        .build();
+  }
+
+  private FeedCommentSearchCondition createCondition(FeedCommentGetParamRequest request) {
+    return FeedCommentSearchCondition.builder()
+        .feedId(request.getFeedId())
+        .cursor(request.getCursor())
+        .idAfter(request.getIdAfter())
+        .limit(request.getLimit())
+        .sortBy("createdAt")
+        .sortDirection(SortDirection.DESCENDING)
+        .build();
+  }
+
+  @Test
+  @DisplayName("Feed에 댓글을 성공적으로 작성한다")
+  void createFeedComment_success() {
+    // given
+    FeedCommentCreateRequest request = createRequest(authorId, feedId, commentContent1);
+    given(feedRepository.findById(feedId)).willReturn(Optional.of(feed));
+    given(userRepository.findById(authorId)).willReturn(Optional.of(author));
+    given(feedCommentMapper.toEntity(feed, author, request.getContent())).willReturn(comment1);
+    given(feedCommentRepository.save(comment1)).willReturn(comment1);
+    given(feedCommentMapper.toDto(comment1, authorDto)).willReturn(commentDto1);
+
+    // when
+    FeedCommentDto result = feedCommentService.createFeedComment(feedId, request);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(commentId1);
+    assertThat(result.getFeedId()).isEqualTo(feedId);
+    assertThat(result.getAuthor().userId()).isEqualTo(authorId);
+  }
+
+  @Test
+  @DisplayName("사용자를 찾지 못해 댓글 생성에 실패합니다.")
+  void createComment_failed_cannot_find_feed() {
+    // given
+    UUID failedFeedId = UUID.randomUUID();
+    FeedCommentCreateRequest failedRequest = createRequest(authorId, failedFeedId, commentContent1);
+
+    given(feedRepository.findById(failedFeedId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> feedCommentService.createFeedComment(failedFeedId, failedRequest))
+        .isInstanceOf(FeedNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("사용자를 찾지 못해 댓글 생성에 실패한다")
+  void createComment_failed_cannot_find_user() {
+    // given
+    UUID failedAuthorId = UUID.randomUUID();
+    FeedCommentCreateRequest failedRequest = createRequest(failedAuthorId, feedId, commentContent1);
+
+    given(feedRepository.findById(feedId)).willReturn(Optional.of(feed));
+    given(userRepository.findById(failedAuthorId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> feedCommentService.createFeedComment(feedId, failedRequest))
+        .isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("특정 피드의 모든 댓글을 삭제한다")
+  void deleteFeedCommentsByFeed_success() {
+    // given
+    feedCommentList = List.of(comment1, comment2);
+    given(feedCommentRepository.findAllByFeed(feed)).willReturn(feedCommentList);
+
+    // when
+    feedCommentService.deleteFeedCommentsByFeed(feed);
+
+    // then
+    then(feedCommentRepository).should(times(1)).findAllByFeed(feed);
+    then(feedCommentRepository).should(times(1)).deleteAll(feedCommentList);
+  }
+
+  @Test
+  @DisplayName("페이지네이션이 적용된 특정 피드의 댓글 리스트를 성공적으로 불러온다")
+  void getFeedList_success() {
+    // given
+    feedCommentList = List.of(comment1, comment2);
+    commentTotalCount = feedCommentList.size();
+    FeedCommentGetParamRequest paramRequest = createParamRequest(null, null,
+        feedCommentList.size());
+    FeedCommentSearchCondition condition = createCondition(paramRequest);
+    commentSlice = new SliceImpl<>(feedCommentList, PageRequest.of(0, feedCommentList.size()),
+        false);
+
+    given(userRepository.findAllById(Set.of(authorId))).willReturn(List.of(author));
+    given(
+        feedCommentRepository.searchFeedComments(any(FeedCommentSearchCondition.class))).willReturn(
+        commentSlice);
+    given(feedCommentRepository.getTotalFeedCommentCount(feedId)).willReturn(commentTotalCount);
+    given(feedCommentMapper.toDto(comment1, authorDto)).willReturn(commentDto1);
+    given(feedCommentMapper.toDto(comment2, authorDto)).willReturn(commentDto2);
+
+    // when
+    PageResponse<FeedCommentDto> resultList = feedCommentService.getFeedComments(feedId,
+        paramRequest);
+
+    // then
+    assertThat(resultList).isNotNull();
+    assertThat(resultList.data()).doesNotContainNull();
+    assertThat(resultList.data()).hasSize(2);
+    assertThat(resultList.data())
+        .extracting(FeedCommentDto::getId)
+        .containsExactly(commentId1, commentId2);
+    assertThat(resultList.hasNext()).isFalse();
+    assertThat(resultList.sortBy()).isEqualTo(condition.getSortBy());
+    assertThat(resultList.sortDirection()).isEqualTo(condition.getSortDirection().name());
+
+    // verify
+    verify(feedCommentRepository).searchFeedComments(any(FeedCommentSearchCondition.class));
+    verify(feedCommentRepository).getTotalFeedCommentCount(feedId);
+    verify(feedCommentMapper).toDto(comment1, authorDto);
+    verify(feedCommentMapper).toDto(comment2, authorDto);
+  }
+
+}

--- a/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImplTest.java
@@ -18,6 +18,7 @@ import com.codeit.weatherwear.domain.feed.entity.Feed;
 import com.codeit.weatherwear.domain.feed.exception.FeedNotFoundException;
 import com.codeit.weatherwear.domain.feed.mapper.FeedMapper;
 import com.codeit.weatherwear.domain.feed.repository.FeedRepository;
+import com.codeit.weatherwear.domain.feed.service.FeedCommentService;
 import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
 import com.codeit.weatherwear.domain.location.entity.Location;
 import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
@@ -59,6 +60,8 @@ class FeedServiceImplTest {
 
   @Mock
   private OotdService ootdService;
+  @Mock
+  private FeedCommentService feedCommentService;
 
   @Mock
   private FeedMapper feedMapper;
@@ -364,6 +367,7 @@ class FeedServiceImplTest {
 
     // verify
     verify(feedRepository).findById(feedId);
+    verify(feedCommentService).deleteFeedCommentsByFeed(mockFeed);
     verify(feedRepository).delete(mockFeed);
     verify(feedMapper).toDto(eq(mockFeed), eq(mockAuthorDto), any(WeatherSummaryDto.class),
         eq(List.of(mockOotdDto1, mockOotdDto2)), eq(false));


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#79  #37

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

feat/79/add-feed-comment -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

Feed 댓글 관련 생성, 삭제, 조회 기능을 추가했습니다.
이와 동시에, 관련 Service 로직 테스트를 추가했습니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

테스트는 전부 통과했습니다.

![image](https://github.com/user-attachments/assets/815bf758-de8e-4ac8-ac9d-32470dd5b629)

또한, 프론트엔드를 실행시켜 제대로 수행되는지 확인을 했을 때에도 잘 나오는 것을 확인했습니다.
(댓글이 무한 증식하는건.. 코드 문제가 아니라 프론트 문제입니다.. 문의를 드린 이후 확인하시고 조치하겠다고 답변 받은 상황이에요)

![250701_feed comment](https://github.com/user-attachments/assets/0f1c9852-cb1b-4395-abe7-f9205a5e44da)


### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

### 🔊 추가 코멘트

❗nextCursor/nextIdAfter 지정(페이지네이션) 관련 이슈가 있어서 해당 부분은 PR 이후에 수정하여 다음 날 오전 PR에 추가할 예정입니다.

앞전에 코드 리뷰시에 말씀해 주셨던 `EnumConverter`의 경우, 리팩토링할 때 수정하는 것이 맞다고 판단했습니다.
따라서 추후 리팩토링 시 해당 부분 수정할 예정입니다. (Enum 객체 내부에 넣을 예정)

소영님의 리뷰를 보고 한 번 Slice로 적용해 보았는데, 서비스 로직이나 책임 면에서 더 깔끔한 것 같더라고요. 추후 Feed 리팩토링 시 Slice로 바꿔서 적용해 볼 예정입니다.
