### PR TITLE
Feat: Feed 좋아요 API 구현

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedController.java
@@ -5,12 +5,14 @@ import com.codeit.weatherwear.domain.feed.dto.request.FeedGetParamRequest;
 import com.codeit.weatherwear.domain.feed.dto.request.FeedUpdateRequest;
 import com.codeit.weatherwear.domain.feed.dto.response.FeedDto;
 import com.codeit.weatherwear.domain.feed.service.FeedService;
+import com.codeit.weatherwear.domain.security.customauthentication.CustomUserDetails;
 import com.codeit.weatherwear.global.response.PageResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -31,29 +33,35 @@ public class FeedController {
   // 피드 목록 조회
   @GetMapping
   public ResponseEntity<PageResponse<FeedDto>> getFeedList(
-      @ModelAttribute @Valid FeedGetParamRequest paramRequest
+      @ModelAttribute @Valid FeedGetParamRequest paramRequest,
+      @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-    return ResponseEntity.ok(feedService.getFeedList(paramRequest));
+    return ResponseEntity.ok(feedService.getFeedList(paramRequest, userDetails.getUserId()));
   }
 
   // 피드 등록
   @PostMapping
-  public ResponseEntity<FeedDto> createFeed(@RequestBody FeedCreateRequest feedCreateRequest) {
+  public ResponseEntity<FeedDto> createFeed(@RequestBody FeedCreateRequest feedCreateRequest,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
     return ResponseEntity.status(HttpStatus.CREATED)
-        .body(feedService.createFeed(feedCreateRequest));
+        .body(feedService.createFeed(feedCreateRequest, userDetails.getUserId()));
   }
 
   // 피드 갱신 (정보 업데이트)
   @PatchMapping("/{feedId}")
   public ResponseEntity<FeedDto> updateFeed(
       @PathVariable UUID feedId,
-      @RequestBody FeedUpdateRequest feedUpdateRequest) {
-    return ResponseEntity.ok(feedService.updateFeed(feedId, feedUpdateRequest));
+      @RequestBody FeedUpdateRequest feedUpdateRequest,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.ok(
+        feedService.updateFeed(feedId, feedUpdateRequest, userDetails.getUserId()));
   }
 
   // 피드 삭제
   @DeleteMapping("/{feedId}")
-  public ResponseEntity<FeedDto> deleteFeed(@PathVariable UUID feedId) {
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).body(feedService.deleteFeed(feedId));
+  public ResponseEntity<FeedDto> deleteFeed(@PathVariable UUID feedId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.status(HttpStatus.NO_CONTENT)
+        .body(feedService.deleteFeed(feedId, userDetails.getUserId()));
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedLikeController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedLikeController.java
@@ -21,7 +21,7 @@ public class FeedLikeController {
   private final FeedLikeService feedLikeService;
 
   @PostMapping
-  public ResponseEntity<FeedDto> addCommentLike(
+  public ResponseEntity<FeedDto> addFeedLike(
       @PathVariable UUID feedId,
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
@@ -29,7 +29,7 @@ public class FeedLikeController {
   }
 
   @DeleteMapping
-  public ResponseEntity<Void> deleteCommentLike(
+  public ResponseEntity<Void> deleteFeedLike(
       @PathVariable UUID feedId,
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {

--- a/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedLikeController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedLikeController.java
@@ -33,7 +33,7 @@ public class FeedLikeController {
       @PathVariable UUID feedId,
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-
+    feedLikeService.deleteFeedLike(feedId, userDetails.getUserId());
     return ResponseEntity.ok(null);
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedLikeController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedLikeController.java
@@ -1,0 +1,41 @@
+package com.codeit.weatherwear.domain.feed.controller;
+
+import com.codeit.weatherwear.domain.feed.dto.response.FeedDto;
+import com.codeit.weatherwear.domain.feed.service.FeedLikeService;
+import com.codeit.weatherwear.domain.security.customauthentication.CustomUserDetails;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/feeds/{feedId}/like")
+@RequiredArgsConstructor
+public class FeedLikeController {
+
+  private final FeedLikeService feedLikeService;
+
+  @PostMapping
+  public ResponseEntity<FeedDto> addCommentLike(
+      @PathVariable UUID feedId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    return ResponseEntity.ok(feedLikeService.addFeedLike(feedId, userDetails.getUserId()));
+  }
+
+  @DeleteMapping
+  public ResponseEntity<Void> deleteCommentLike(
+      @PathVariable UUID feedId,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+
+    return ResponseEntity.ok(null);
+  }
+
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/entity/Feed.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/entity/Feed.java
@@ -71,10 +71,6 @@ public class Feed {
     this.content = content;
   }
 
-  public void updateLikeCount(int likeCount) {
-    this.likeCount = likeCount;
-  }
-
   public void increaseLikeCount() {
     this.likeCount++;
   }
@@ -83,17 +79,8 @@ public class Feed {
     this.likeCount--;
   }
 
-  public void updateCommentCount(int commentCount) {
-    this.commentCount = commentCount;
-  }
-
   public void increaseCommentCount() {
     this.commentCount++;
   }
-
-  public void decreaseCommentCount() {
-    this.commentCount--;
-  }
-
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/feed/entity/Feed.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/entity/Feed.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Min;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -49,9 +50,11 @@ public class Feed {
   private String content;
 
   @Column(name = "like_count")
+  @Min(value = 0, message = "좋아요 개수는 음수가 될 수 없습니다")
   private int likeCount = 0;
 
   @Column(name = "comment_count")
+  @Min(value = 0, message = "댓글 수는 음수가 될 수 없습니다")
   private int commentCount = 0;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -76,7 +79,9 @@ public class Feed {
   }
 
   public void decreaseLikeCount() {
-    this.likeCount--;
+    if (likeCount > 0) {
+      likeCount--;
+    }
   }
 
   public void increaseCommentCount() {

--- a/src/main/java/com/codeit/weatherwear/domain/feed/mapper/FeedLikeMapper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/mapper/FeedLikeMapper.java
@@ -1,0 +1,20 @@
+package com.codeit.weatherwear.domain.feed.mapper;
+
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.feed.entity.FeedLike;
+import com.codeit.weatherwear.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FeedLikeMapper {
+
+  public FeedLike toEntity(Feed feed, User user) {
+    return FeedLike.builder()
+        .feed(feed)
+        .user(user)
+        .build();
+  }
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/repository/FeedLikeRepository.java
@@ -1,11 +1,23 @@
 package com.codeit.weatherwear.domain.feed.repository;
 
+import com.codeit.weatherwear.domain.feed.entity.Feed;
 import com.codeit.weatherwear.domain.feed.entity.FeedLike;
+import com.codeit.weatherwear.domain.user.entity.User;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedLikeRepository extends JpaRepository<FeedLike, UUID> {
 
+  @Query("select fl from FeedLike fl where fl.feed.id=:feedId and fl.user.id=:userId")
+  Optional<FeedLike> findFeedLikeByFeedIdAndUserId(@Param("feedId") UUID feedId,
+      @Param("userId") UUID userId);
+
+  boolean existsFeedLikeByFeedAndUser(Feed feed, User user);
+
+  void deleteAllByFeed(Feed feed);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/FeedLikeService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/FeedLikeService.java
@@ -1,0 +1,16 @@
+package com.codeit.weatherwear.domain.feed.service;
+
+import com.codeit.weatherwear.domain.feed.dto.response.FeedDto;
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import java.util.UUID;
+
+public interface FeedLikeService {
+
+  FeedDto addFeedLike(UUID feedId, UUID currentUserId);
+
+  void deleteFeedLike(UUID feedId, UUID currentUserId);
+
+  void deleteAllFeedLikeInFeed(Feed feed);
+
+  boolean isLikedByMe(Feed feed, UUID currentUserId);
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/FeedService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/FeedService.java
@@ -10,13 +10,13 @@ import java.util.UUID;
 
 public interface FeedService {
 
-  PageResponse<FeedDto> getFeedList(FeedGetParamRequest paramRequest);
+  PageResponse<FeedDto> getFeedList(FeedGetParamRequest paramRequest, UUID currentUserId);
 
-  FeedDto createFeed(FeedCreateRequest feedCreateRequest);
+  FeedDto createFeed(FeedCreateRequest feedCreateRequest, UUID currentUserId);
 
-  FeedDto updateFeed(UUID feedId, FeedUpdateRequest feedUpdateRequest);
+  FeedDto updateFeed(UUID feedId, FeedUpdateRequest feedUpdateRequest, UUID currentUserId);
 
-  FeedDto deleteFeed(UUID feedId);
+  FeedDto deleteFeed(UUID feedId, UUID currentUserId);
 
   WeatherSummaryDto getMockWeatherSummaryDto();
 

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImpl.java
@@ -39,6 +39,7 @@ public class FeedLikeServiceImpl implements FeedLikeService {
   @Transactional
   @Override
   public FeedDto addFeedLike(UUID feedId, UUID currentUserId) {
+    log.debug("Request Add Feed Like - feedId: {}, userId: {}", feedId, currentUserId);
     User user = userRepository.findById(currentUserId).orElseThrow(UserNotFoundException::new);
     Feed feed = feedRepository.findById(feedId)
         .orElseThrow(() -> new FeedNotFoundException(feedId));
@@ -49,8 +50,10 @@ public class FeedLikeServiceImpl implements FeedLikeService {
 
     UserSummaryDto userSummaryDto = UserSummaryDto.from(feedLike.getUser());
     List<OotdDto> ootds = ootdService.findOotdByFeedId(feed.getId());
+    FeedDto feedDto = feedMapper.toDto(feed, userSummaryDto, null, ootds, true);
 
-    return feedMapper.toDto(feed, userSummaryDto, null, ootds, true);
+    log.info("Add Feed Like Success");
+    return feedDto;
   }
 
   /**
@@ -62,6 +65,7 @@ public class FeedLikeServiceImpl implements FeedLikeService {
   @Transactional
   @Override
   public void deleteFeedLike(UUID feedId, UUID currentUserId) {
+    log.debug("Request Delete Feed Like - feedId: {}, userId: {}", feedId, currentUserId);
     Feed feed = feedRepository.findById(feedId)
         .orElseThrow(() -> new FeedNotFoundException(feedId));
 
@@ -71,6 +75,7 @@ public class FeedLikeServiceImpl implements FeedLikeService {
           feedLikeRepository.delete(feedLike);
         }
     );
+    log.info("Delete Feed Like Success");
   }
 
   /**
@@ -81,12 +86,17 @@ public class FeedLikeServiceImpl implements FeedLikeService {
   @Transactional
   @Override
   public void deleteAllFeedLikeInFeed(Feed feed) {
+    log.debug("Request Delete All Feed Like - feedId: {}", feed.getId());
+
     feedLikeRepository.deleteAllByFeed(feed);
+    log.info("Delete All Likes in Feed Success");
   }
 
   @Transactional(readOnly = true)
   @Override
   public boolean isLikedByMe(Feed feed, UUID currentUserId) {
+    log.debug("Request isLikedByMe - feedId: {}, userId: {}", feed.getId(), currentUserId);
+
     User me = userRepository.findById(currentUserId).orElseThrow(UserNotFoundException::new);
     return feedLikeRepository.existsFeedLikeByFeedAndUser(feed, me);
   }

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImpl.java
@@ -44,11 +44,11 @@ public class FeedLikeServiceImpl implements FeedLikeService {
         .orElseThrow(() -> new FeedNotFoundException(feedId));
 
     FeedLike feedLike = feedLikeMapper.toEntity(feed, user);
-    FeedLike saved = feedLikeRepository.save(feedLike);
+    feedLikeRepository.save(feedLike);
     feed.increaseLikeCount();
 
     UserSummaryDto userSummaryDto = UserSummaryDto.from(feedLike.getUser());
-    List<OotdDto> ootds = ootdService.findOotdByFeedId(saved.getId());
+    List<OotdDto> ootds = ootdService.findOotdByFeedId(feed.getId());
 
     return feedMapper.toDto(feed, userSummaryDto, null, ootds, true);
   }

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImpl.java
@@ -1,0 +1,93 @@
+package com.codeit.weatherwear.domain.feed.service.impl;
+
+import com.codeit.weatherwear.domain.feed.dto.response.FeedDto;
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.feed.entity.FeedLike;
+import com.codeit.weatherwear.domain.feed.exception.FeedNotFoundException;
+import com.codeit.weatherwear.domain.feed.mapper.FeedLikeMapper;
+import com.codeit.weatherwear.domain.feed.mapper.FeedMapper;
+import com.codeit.weatherwear.domain.feed.repository.FeedLikeRepository;
+import com.codeit.weatherwear.domain.feed.repository.FeedRepository;
+import com.codeit.weatherwear.domain.feed.service.FeedLikeService;
+import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
+import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
+import com.codeit.weatherwear.domain.ootd.service.OotdService;
+import com.codeit.weatherwear.domain.user.entity.User;
+import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
+import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedLikeServiceImpl implements FeedLikeService {
+
+  private final UserRepository userRepository;
+  private final FeedRepository feedRepository;
+  private final FeedLikeRepository feedLikeRepository;
+
+  private final OotdService ootdService;
+
+  private final FeedMapper feedMapper;
+  private final FeedLikeMapper feedLikeMapper;
+
+  @Transactional
+  @Override
+  public FeedDto addFeedLike(UUID feedId, UUID currentUserId) {
+    User user = userRepository.findById(currentUserId).orElseThrow(UserNotFoundException::new);
+    Feed feed = feedRepository.findById(feedId)
+        .orElseThrow(() -> new FeedNotFoundException(feedId));
+
+    FeedLike feedLike = feedLikeMapper.toEntity(feed, user);
+    FeedLike saved = feedLikeRepository.save(feedLike);
+    feed.increaseLikeCount();
+
+    UserSummaryDto userSummaryDto = UserSummaryDto.from(feedLike.getUser());
+    List<OotdDto> ootds = ootdService.findOotdByFeedId(saved.getId());
+
+    return feedMapper.toDto(feed, userSummaryDto, null, ootds, true);
+  }
+
+  /**
+   * 좋아요 취소
+   *
+   * @param feedId
+   * @param currentUserId
+   */
+  @Transactional
+  @Override
+  public void deleteFeedLike(UUID feedId, UUID currentUserId) {
+    Feed feed = feedRepository.findById(feedId)
+        .orElseThrow(() -> new FeedNotFoundException(feedId));
+
+    feedLikeRepository.findFeedLikeByFeedIdAndUserId(feedId, currentUserId).ifPresent(
+        feedLike -> {
+          feed.decreaseLikeCount();
+          feedLikeRepository.delete(feedLike);
+        }
+    );
+  }
+
+  /**
+   * 피드 완전 삭제 시 좋아요도 함께 삭제
+   *
+   * @param feed
+   */
+  @Transactional
+  @Override
+  public void deleteAllFeedLikeInFeed(Feed feed) {
+    feedLikeRepository.deleteAllByFeed(feed);
+  }
+
+  @Transactional(readOnly = true)
+  @Override
+  public boolean isLikedByMe(Feed feed, UUID currentUserId) {
+    User me = userRepository.findById(currentUserId).orElseThrow(UserNotFoundException::new);
+    return feedLikeRepository.existsFeedLikeByFeedAndUser(feed, me);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImpl.java
@@ -10,6 +10,7 @@ import com.codeit.weatherwear.domain.feed.exception.FeedNotFoundException;
 import com.codeit.weatherwear.domain.feed.mapper.FeedMapper;
 import com.codeit.weatherwear.domain.feed.repository.FeedRepository;
 import com.codeit.weatherwear.domain.feed.service.FeedCommentService;
+import com.codeit.weatherwear.domain.feed.service.FeedLikeService;
 import com.codeit.weatherwear.domain.feed.service.FeedService;
 import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
 import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
@@ -41,10 +42,11 @@ public class FeedServiceImpl implements FeedService {
   private final FeedRepository feedRepository;
   private final OotdService ootdService;
   private final FeedCommentService feedCommentService;
+  private final FeedLikeService feedLikeService;
 
   @Transactional
   @Override
-  public PageResponse<FeedDto> getFeedList(FeedGetParamRequest paramRequest) {
+  public PageResponse<FeedDto> getFeedList(FeedGetParamRequest paramRequest, UUID currentUserId) {
     log.info("Request Get Feed List");
 
     FeedSearchCondition condition = paramRequest.toSearchCondition();
@@ -54,7 +56,7 @@ public class FeedServiceImpl implements FeedService {
     boolean hasNext = feedList.size() > condition.getLimit();
 
     List<Feed> resultList = hasNext ? feedList.subList(0, condition.getLimit()) : feedList;
-    List<FeedDto> feedDtoList = resultList.stream().map(this::toFeedDto)
+    List<FeedDto> feedDtoList = resultList.stream().map(feed -> toFeedDto(feed, currentUserId))
         .collect(Collectors.toList());
 
     return toPageResponse(feedDtoList, condition, hasNext);
@@ -62,7 +64,7 @@ public class FeedServiceImpl implements FeedService {
 
   @Transactional
   @Override
-  public FeedDto createFeed(FeedCreateRequest feedCreateRequest) {
+  public FeedDto createFeed(FeedCreateRequest feedCreateRequest, UUID currentUserId) {
     log.info("Request Create Feed - authorId: {}", feedCreateRequest.getAuthorId());
 
     User author = userRepository.findById(feedCreateRequest.getAuthorId())
@@ -72,33 +74,36 @@ public class FeedServiceImpl implements FeedService {
     Feed saved = feedRepository.save(feed);
     List<OotdDto> ootdList = ootdService.createOotdList(feed, feedCreateRequest.getClothesIds());
 
-    return toFeedDto(saved, ootdList);
+    return toFeedDto(saved, ootdList, false);
   }
 
   @Transactional
   @Override
-  public FeedDto updateFeed(UUID feedId, FeedUpdateRequest feedUpdateRequest) {
+  public FeedDto updateFeed(UUID feedId, FeedUpdateRequest feedUpdateRequest, UUID currentUserId) {
     log.info("Request Update Feed - feedId: {}", feedId);
 
     Feed feed = feedRepository.findById(feedId)
         .orElseThrow(() -> new FeedNotFoundException(feedId));
     feed.updateContent(feedUpdateRequest.getContent());
 
-    return toFeedDto(feed);
+    return toFeedDto(feed, currentUserId);
   }
 
   @Transactional
   @Override
-  public FeedDto deleteFeed(UUID feedId) {
+  public FeedDto deleteFeed(UUID feedId, UUID currentUserId) {
     log.info("Request Delete Feed - feedId: {}", feedId);
 
     Feed feed = feedRepository.findById(feedId)
         .orElseThrow(() -> new FeedNotFoundException(feedId));
+    boolean likedByMe = feedLikeService.isLikedByMe(feed, currentUserId);
+
+    feedLikeService.deleteAllFeedLikeInFeed(feed);
     feedCommentService.deleteFeedCommentsByFeed(feed);
     feedRepository.delete(feed);
     List<OotdDto> ootds = ootdService.deleteOotdByFeedId(feedId);
 
-    return toFeedDto(feed, ootds);
+    return toFeedDto(feed, ootds, likedByMe);
   }
 
   // 임시로 만들어진 WeatherSummeryDto 인스턴스를 반환합니다.
@@ -127,24 +132,22 @@ public class FeedServiceImpl implements FeedService {
   }
 
   // 생성/삭제
-  private FeedDto toFeedDto(Feed feed, List<OotdDto> ootds) {
+  private FeedDto toFeedDto(Feed feed, List<OotdDto> ootds, boolean likedByMe) {
     UserSummaryDto authorDto = UserSummaryDto.from(feed.getAuthor());
     WeatherSummaryDto weatherSummaryDto = getMockWeatherSummaryDto();
 
-    // todo: likedByMe 로직 필요 - feedLike 도메인
-
-    return feedMapper.toDto(feed, authorDto, weatherSummaryDto, ootds, false);
+    return feedMapper.toDto(feed, authorDto, weatherSummaryDto, ootds, likedByMe);
   }
 
   // 일반적인 상황 (조회/갱신)
-  private FeedDto toFeedDto(Feed feed) {
+  private FeedDto toFeedDto(Feed feed, UUID currentUserId) {
     UserSummaryDto authorDto = UserSummaryDto.from(feed.getAuthor());
     WeatherSummaryDto weatherSummaryDto = getMockWeatherSummaryDto();
     List<OotdDto> ootds = ootdService.findOotdByFeedId(feed.getId());
 
-    // todo: likedByMe 로직 필요 - feedLike 도메인
+    boolean likedByMe = feedLikeService.isLikedByMe(feed, currentUserId);
 
-    return feedMapper.toDto(feed, authorDto, weatherSummaryDto, ootds, false);
+    return feedMapper.toDto(feed, authorDto, weatherSummaryDto, ootds, likedByMe);
   }
 
   private PageResponse<FeedDto> toPageResponse(List<FeedDto> dtoList, FeedSearchCondition condition,

--- a/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImplTest.java
@@ -1,0 +1,258 @@
+package com.codeit.weatherwear.domain.feed.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.codeit.weatherwear.domain.feed.dto.response.FeedDto;
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.feed.entity.FeedLike;
+import com.codeit.weatherwear.domain.feed.exception.FeedNotFoundException;
+import com.codeit.weatherwear.domain.feed.mapper.FeedLikeMapper;
+import com.codeit.weatherwear.domain.feed.mapper.FeedMapper;
+import com.codeit.weatherwear.domain.feed.repository.FeedLikeRepository;
+import com.codeit.weatherwear.domain.feed.repository.FeedRepository;
+import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
+import com.codeit.weatherwear.domain.location.entity.Location;
+import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
+import com.codeit.weatherwear.domain.ootd.service.OotdService;
+import com.codeit.weatherwear.domain.user.entity.Gender;
+import com.codeit.weatherwear.domain.user.entity.Role;
+import com.codeit.weatherwear.domain.user.entity.User;
+import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
+import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class FeedLikeServiceImplTest {
+
+  @InjectMocks
+  private FeedLikeServiceImpl feedLikeService;
+
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private FeedRepository feedRepository;
+  @Mock
+  private FeedLikeRepository feedLikeRepository;
+
+  @Mock
+  private OotdService ootdService;
+
+  @Mock
+  private FeedMapper feedMapper;
+  @Mock
+  private FeedLikeMapper feedLikeMapper;
+
+  private UUID feedId;
+  private UUID currentUserId;
+  private UUID feedLikeId;
+
+  private Feed feed;
+  private FeedLike feedLike;
+
+  private User currentUser;
+  private UserSummaryDto currentUserDto;
+
+  private List<OotdDto> ootds;
+  private FeedDto feedDto;
+
+  @BeforeEach
+  void setUp() {
+    feedId = UUID.randomUUID();
+    currentUserId = UUID.randomUUID();
+    feedLikeId = UUID.randomUUID();
+
+    currentUser = User.builder()
+        .id(currentUserId)
+        .email("test@example.com")
+        .name("홍길동")
+        .password("!password1234")
+        .role(Role.USER)
+        .locked(false)
+        .gender(Gender.FEMALE)
+        .birthDate(LocalDate.of(2000, 1, 1))
+        .temperatureSensitivity(10)
+        .profileImageUrl(null)
+        .location(mock(Location.class))
+        .createdAt(Instant.now())
+        .updatedAt(Instant.now())
+        .build();
+
+    currentUserDto = UserSummaryDto.from(currentUser);
+
+    ootds = List.of(mock(OotdDto.class));
+  }
+
+  private FeedDto createFeedDto(int likeCount) {
+    FeedDto dto = mock(FeedDto.class);
+    given(dto.getLikeCount()).willReturn(likeCount);
+    given(dto.getId()).willReturn(feedId);
+    return dto;
+  }
+
+  private FeedLike createFeedLike(Feed feed) {
+    FeedLike feedLike = FeedLike.builder()
+        .user(currentUser)
+        .feed(feed)
+        .build();
+    ReflectionTestUtils.setField(feedLike, "id", feedLikeId);
+
+    return feedLike;
+  }
+
+  @Test
+  @DisplayName("좋아요를 성공적으로 추가한다")
+  void addFeedLike_success() {
+    // given
+    feed = mock(Feed.class);
+    given(feed.getId()).willReturn(feedId);
+    feedDto = createFeedDto(1);
+    feedLike = createFeedLike(feed);
+
+    given(userRepository.findById(currentUserId)).willReturn(Optional.of(currentUser));
+    given(feedRepository.findById(feedId)).willReturn(Optional.of(feed));
+    given(feedLikeMapper.toEntity(feed, currentUser)).willReturn(feedLike);
+    given(feedLikeRepository.save(feedLike)).willReturn(feedLike);
+    given(ootdService.findOotdByFeedId(feedId)).willReturn(ootds);
+    given(feedMapper.toDto(any(Feed.class), any(UserSummaryDto.class), any(), anyList(),
+        anyBoolean())).willReturn(feedDto);
+
+    // when
+    FeedDto result = feedLikeService.addFeedLike(feedId, currentUserId);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(feed.getId());
+    assertThat(result.getLikeCount()).isEqualTo(1);
+
+    // verify
+    verify(feed).increaseLikeCount();
+  }
+
+  @Test
+  @DisplayName("사용자를 찾지 못해 좋아요 추가 로직을 수행하지 못한다")
+  void addFeedLike_failed_cannot_find_user() {
+    // given
+    UUID failedId = UUID.randomUUID();
+
+    given(userRepository.findById(failedId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> feedLikeService.addFeedLike(feedId, failedId))
+        .isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("피드를 찾지 못해 좋아요 추가 로직을 수행하지 못한다")
+  void addFeedLike_failed_cannot_find_feed() {
+    // given
+    UUID failedId = UUID.randomUUID();
+
+    given(userRepository.findById(currentUserId)).willReturn(Optional.of(currentUser));
+    given(feedRepository.findById(failedId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> feedLikeService.addFeedLike(failedId, currentUserId))
+        .isInstanceOf(FeedNotFoundException.class);
+  }
+
+
+  @Test
+  @DisplayName("좋아요를 성공적으로 취소한다")
+  void deleteFeedLike_success() {
+    // given
+    feed = mock(Feed.class);
+    given(feed.getId()).willReturn(feedId);
+    feedLike = createFeedLike(feed);
+
+    given(feedRepository.findById(feed.getId())).willReturn(Optional.of(feed));
+    given(feedLikeRepository.findFeedLikeByFeedIdAndUserId(feedId, currentUserId)).willReturn(
+        Optional.of(feedLike));
+
+    // when
+    feedLikeService.deleteFeedLike(feedId, currentUserId);
+
+    // then
+    verify(feed).decreaseLikeCount();
+    verify(feedLikeRepository).delete(feedLike);
+  }
+
+  @Test
+  @DisplayName("피드를 찾지 못해 좋아요 취소 로직을 수행하지 못한다")
+  void deleteFeedLike_failed_cannot_find_feed() {
+    // given
+    UUID failedId = UUID.randomUUID();
+
+    given(feedRepository.findById(failedId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> feedLikeService.deleteFeedLike(failedId, currentUserId))
+        .isInstanceOf(FeedNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("피드 삭제 시 해당 피드와 관련된 모든 좋아요도 함께 삭제한다")
+  void deleteAllFeedLikeInFeed_success() {
+    // given
+    feed = mock(Feed.class);
+
+    willDoNothing().given(feedLikeRepository).deleteAllByFeed(feed);
+
+    // when
+    feedLikeService.deleteAllFeedLikeInFeed(feed);
+
+    // then
+    verify(feedLikeRepository).deleteAllByFeed(feed);
+  }
+
+  @Test
+  @DisplayName("해당 게시물에 좋아요 선택 여부를 반환한다")
+  void isLikedByMe_success() {
+    // given
+    feed = mock(Feed.class);
+    given(userRepository.findById(currentUserId)).willReturn(Optional.of(currentUser));
+    given(feedLikeRepository.existsFeedLikeByFeedAndUser(feed, currentUser)).willReturn(false);
+
+    // when
+    boolean result = feedLikeService.isLikedByMe(feed, currentUserId);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  @DisplayName("사용자를 찾지 못해 좋아요 선택 여부를 반환하지 못한다")
+  void isLikedByMe_failed_cannot_find_user() {
+    // given
+    feed = mock(Feed.class);
+    UUID failedId = UUID.randomUUID();
+
+    given(userRepository.findById(failedId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> feedLikeService.isLikedByMe(feed, failedId))
+        .isInstanceOf(UserNotFoundException.class);
+  }
+
+}

--- a/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImplTest.java
@@ -19,6 +19,7 @@ import com.codeit.weatherwear.domain.feed.exception.FeedNotFoundException;
 import com.codeit.weatherwear.domain.feed.mapper.FeedMapper;
 import com.codeit.weatherwear.domain.feed.repository.FeedRepository;
 import com.codeit.weatherwear.domain.feed.service.FeedCommentService;
+import com.codeit.weatherwear.domain.feed.service.FeedLikeService;
 import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
 import com.codeit.weatherwear.domain.location.entity.Location;
 import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
@@ -62,6 +63,8 @@ class FeedServiceImplTest {
   private OotdService ootdService;
   @Mock
   private FeedCommentService feedCommentService;
+  @Mock
+  private FeedLikeService feedLikeService;
 
   @Mock
   private FeedMapper feedMapper;
@@ -71,6 +74,7 @@ class FeedServiceImplTest {
 
   private FeedCreateRequest mockRequest;
   private UUID authorId;
+  private UUID currentUserId;
   private UUID weatherId;
   private String mockContent;
 
@@ -105,6 +109,7 @@ class FeedServiceImplTest {
     mockLocation = new Location(37.513068, 127.102570, 961159, 1953082, "서울 송파구 신천동");
 
     authorId = UUID.randomUUID();
+    currentUserId = authorId;
     weatherId = UUID.randomUUID();
     clothId1 = UUID.randomUUID();
     clothId2 = UUID.randomUUID();
@@ -241,7 +246,7 @@ class FeedServiceImplTest {
         eq(false))).willReturn(mockFeedDto);
 
     // when
-    FeedDto result = feedService.createFeed(mockRequest);
+    FeedDto result = feedService.createFeed(mockRequest, currentUserId);
 
     // then
     assertThat(result).isNotNull();
@@ -273,7 +278,7 @@ class FeedServiceImplTest {
     given(userRepository.findById(failedId)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> feedService.createFeed(failedRequest))
+    assertThatThrownBy(() -> feedService.createFeed(failedRequest, failedId))
         .isInstanceOf(UserNotFoundException.class);
   }
 
@@ -287,12 +292,13 @@ class FeedServiceImplTest {
         anyInt())).willReturn(feedList);
     given(ootdService.findOotdByFeedId(eq(mockFeed.getId()))).willReturn(
         List.of(mockOotdDto1, mockOotdDto2));
+    given(feedLikeService.isLikedByMe(mockFeed, currentUserId)).willReturn(false);
     given(feedMapper.toDto(eq(mockFeed), eq(mockAuthorDto), any(WeatherSummaryDto.class),
         eq(List.of(mockOotdDto1, mockOotdDto2)),
         eq(false))).willReturn(mockFeedDto);
 
     // when
-    PageResponse<FeedDto> resultList = feedService.getFeedList(mockFeedQuery);
+    PageResponse<FeedDto> resultList = feedService.getFeedList(mockFeedQuery, currentUserId);
 
     // then
     assertThat(resultList).isNotNull();
@@ -305,6 +311,7 @@ class FeedServiceImplTest {
 
     // verify
     verify(feedRepository).searchFeeds(any(FeedSearchCondition.class), anyInt());
+    verify(feedLikeService).isLikedByMe(mockFeed, currentUserId);
     verify(feedMapper, times(feedList.size())).toDto(eq(mockFeed), eq(mockAuthorDto),
         any(WeatherSummaryDto.class), eq(List.of(mockOotdDto1, mockOotdDto2)), eq(false));
   }
@@ -318,12 +325,13 @@ class FeedServiceImplTest {
     given(feedRepository.findById(feedId)).willReturn(Optional.of(mockFeed));
     given(ootdService.findOotdByFeedId(eq(mockFeed.getId()))).willReturn(
         List.of(mockOotdDto1, mockOotdDto2));
+    given(feedLikeService.isLikedByMe(mockFeed, currentUserId)).willReturn(false);
     given(feedMapper.toDto(eq(mockFeed), eq(mockAuthorDto), any(WeatherSummaryDto.class),
         eq(List.of(mockOotdDto1, mockOotdDto2)),
         eq(false))).willReturn(updateFeedDto);
 
     // when
-    FeedDto result = feedService.updateFeed(feedId, updateRequest);
+    FeedDto result = feedService.updateFeed(feedId, updateRequest, currentUserId);
 
     // then
     assertThat(result).isNotNull();
@@ -342,7 +350,7 @@ class FeedServiceImplTest {
     given(feedRepository.findById(failedId)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> feedService.updateFeed(failedId, failedRequest))
+    assertThatThrownBy(() -> feedService.updateFeed(failedId, failedRequest, currentUserId))
         .isInstanceOf(FeedNotFoundException.class);
   }
 
@@ -351,6 +359,7 @@ class FeedServiceImplTest {
   void deleteFeed_success() {
     // given
     given(feedRepository.findById(feedId)).willReturn(Optional.of(mockFeed));
+    given(feedLikeService.isLikedByMe(mockFeed, currentUserId)).willReturn(false);
     given(ootdService.deleteOotdByFeedId(eq(mockFeed.getId()))).willReturn(
         List.of(mockOotdDto1, mockOotdDto2));
     given(feedMapper.toDto(eq(mockFeed), eq(mockAuthorDto), any(WeatherSummaryDto.class),
@@ -358,7 +367,7 @@ class FeedServiceImplTest {
         eq(false))).willReturn(mockFeedDto);
 
     // when
-    FeedDto result = feedService.deleteFeed(feedId);
+    FeedDto result = feedService.deleteFeed(feedId, currentUserId);
 
     // then
     assertThat(result).isNotNull();
@@ -367,6 +376,8 @@ class FeedServiceImplTest {
 
     // verify
     verify(feedRepository).findById(feedId);
+    verify(feedLikeService).isLikedByMe(mockFeed, currentUserId);
+    verify(feedLikeService).deleteAllFeedLikeInFeed(mockFeed);
     verify(feedCommentService).deleteFeedCommentsByFeed(mockFeed);
     verify(feedRepository).delete(mockFeed);
     verify(feedMapper).toDto(eq(mockFeed), eq(mockAuthorDto), any(WeatherSummaryDto.class),
@@ -382,7 +393,7 @@ class FeedServiceImplTest {
     given(feedRepository.findById(failedId)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> feedService.deleteFeed(failedId))
+    assertThatThrownBy(() -> feedService.deleteFeed(failedId, authorId))
         .isInstanceOf(FeedNotFoundException.class);
   }
 


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#84 #37 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [x] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

feat/84/add-feed-like-api -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

피드 좋아요 API 기능을 추가했습니다.
- 좋아요 등록
- 좋아요 취소
- 내가 대상 피드에 좋아요 눌렀는지 여부

구현한 서비스 로직에 대하여 테스트 코드를 추가했습니다.
Feed 엔티티에서 사용되지 않는 메서드들을 삭제하였습니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

테스트는 전체 통과하였습니다.
프론트로 테스트 했을 때는 아래 GIF 파일의 모양과 같습니다

![image](https://github.com/user-attachments/assets/ee99756e-6618-40bc-b01a-85cc84e08243)

![250702_feed like](https://github.com/user-attachments/assets/4281d6e9-3d2b-44df-9765-6b59522836e7)

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.