### PR TITLE
Feat: 비밀번호 초기화 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,8 @@ dependencies {
     runtimeOnly "io.jsonwebtoken:jjwt-impl:0.12.5"
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:0.12.5"
 
+    // Java Mail Sender
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 

--- a/src/main/java/com/codeit/weatherwear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/controller/AuthController.java
@@ -1,10 +1,12 @@
 package com.codeit.weatherwear.domain.auth.controller;
 
+import com.codeit.weatherwear.domain.auth.dto.ResetPasswordRequest;
 import com.codeit.weatherwear.domain.auth.service.AuthService;
 import com.codeit.weatherwear.domain.security.dto.TokenRotationResult;
 import com.codeit.weatherwear.domain.security.service.JwtSessionService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseCookie;
@@ -12,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,31 +24,37 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private final AuthService authService;
-    private final JwtSessionService jwtSessionService;
+  private final AuthService authService;
+  private final JwtSessionService jwtSessionService;
 
-    // 액세스 토큰 조회
-    @GetMapping("/me")
-    public ResponseEntity<String> getMe(@CookieValue(value = "refresh_token") Cookie refreshToken) {
-        String accessToken = jwtSessionService.findAccessToken(refreshToken.getValue());
-        return ResponseEntity.ok(accessToken);
-    }
+  // 액세스 토큰 조회
+  @GetMapping("/me")
+  public ResponseEntity<String> getMe(@CookieValue(value = "refresh_token") Cookie refreshToken) {
+    String accessToken = jwtSessionService.findAccessToken(refreshToken.getValue());
+    return ResponseEntity.ok(accessToken);
+  }
 
-    // 토큰 재발급
-    @PostMapping("/refresh")
-    public ResponseEntity<String> rotateToken(
-        @CookieValue(value = "refresh_token") Cookie refreshToken, HttpServletResponse response) {
-        TokenRotationResult result = jwtSessionService.rotateToken(refreshToken.getValue());
-        // 리프레시 토큰을 쿠키로 다시 설정
-        ResponseCookie cookie = ResponseCookie.from("refresh_token", result.refreshToken())
-            .httpOnly(true)
-            .secure(false)
-            .path("/")
-            .sameSite("Strict")
-            .maxAge(30 * 24 * 60 * 60)
-            .build();
-        response.addHeader("Set-Cookie", cookie.toString());
-        return ResponseEntity.ok(result.accessToken());
-    }
+  // 토큰 재발급
+  @PostMapping("/refresh")
+  public ResponseEntity<String> rotateToken(
+      @CookieValue(value = "refresh_token") Cookie refreshToken, HttpServletResponse response) {
+    TokenRotationResult result = jwtSessionService.rotateToken(refreshToken.getValue());
+    // 리프레시 토큰을 쿠키로 다시 설정
+    ResponseCookie cookie = ResponseCookie.from("refresh_token", result.refreshToken())
+        .httpOnly(true)
+        .secure(false)
+        .path("/")
+        .sameSite("Strict")
+        .maxAge(30 * 24 * 60 * 60)
+        .build();
+    response.addHeader("Set-Cookie", cookie.toString());
+    return ResponseEntity.ok(result.accessToken());
+  }
+
+  @PostMapping("/reset-password")
+  public ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+    authService.resetPassword(request);
+    return ResponseEntity.noContent().build();
+  }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/auth/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/dto/ResetPasswordRequest.java
@@ -1,0 +1,10 @@
+package com.codeit.weatherwear.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+
+public record ResetPasswordRequest(
+    @Email
+    String email
+) {
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/service/AuthService.java
@@ -1,6 +1,8 @@
 package com.codeit.weatherwear.domain.auth.service;
 
+import com.codeit.weatherwear.domain.auth.dto.ResetPasswordRequest;
+
 public interface AuthService {
 
-    void resetPassword(String email);
+  void resetPassword(ResetPasswordRequest resetPasswordRequest);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/service/AuthServiceImpl.java
@@ -9,6 +9,8 @@ import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,7 @@ public class AuthServiceImpl implements AuthService {
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
+  private final JavaMailSender javaMailSender;
   private final SecureRandom secureRandom = new SecureRandom();
   private final static String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345678";
 
@@ -31,20 +34,19 @@ public class AuthServiceImpl implements AuthService {
   @Override
   public void resetPassword(ResetPasswordRequest resetPasswordRequest) {
     String email = resetPasswordRequest.email();
-    
-    // TODO: 이메일 전송 로직 추가
 
     User user = userRepository.findByEmail(email)
         .orElseThrow(() -> new UserNotFoundException());
 
-    // 임시 비밀번호
+    // 임시 비밀번호 발급
     String tempPassword = generateTempPassword();
-    String encodedTempPassword = passwordEncoder.encode(tempPassword);
+
+    // 이메일 전송
+    sendTempPasswordEmail(email, tempPassword);
 
     // DB 업데이트
+    String encodedTempPassword = passwordEncoder.encode(tempPassword);
     user.setTempPassword(encodedTempPassword, Instant.now().plusSeconds(PASSWORD_VALIDITY_SECONDS));
-
-    log.info("임시 비밀번호: {}", tempPassword);
   }
 
   // 임시 비밀번호 생성
@@ -57,6 +59,30 @@ public class AuthServiceImpl implements AuthService {
       stringBuffer.append(CHARS.charAt(index));
     }
     return stringBuffer.toString();
+  }
+
+  private void sendTempPasswordEmail(String toEmail, String tempPassword) {
+    String content = """
+        안녕하세요.
+        "옷장을 부탁해" 서비스입니다.
+                
+        요청하신 임시 비밀번호는 아래와 같습니다.
+        --------------
+        %s
+        --------------
+                
+        임시 비밀번호는 발급 시점으로부터 10분 간 유효합니다.
+        로그인 후 반드시 비밀번호를 변경해주세요.
+                
+        감사합니다.        
+        """.formatted(tempPassword);
+
+    SimpleMailMessage message = new SimpleMailMessage();
+    message.setTo(toEmail);
+    message.setSubject("[옷장을 부탁해] 임시 비밀번호 안내");
+    message.setText(content);
+
+    javaMailSender.send(message);
   }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/service/AuthServiceImpl.java
@@ -1,24 +1,62 @@
 package com.codeit.weatherwear.domain.auth.service;
 
-import com.codeit.weatherwear.domain.security.repository.JwtSessionRepository;
-import com.codeit.weatherwear.domain.security.service.JwtSessionService;
+import com.codeit.weatherwear.domain.auth.dto.ResetPasswordRequest;
+import com.codeit.weatherwear.domain.user.entity.User;
+import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import java.security.SecureRandom;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class AuthServiceImpl implements AuthService {
 
-    private final JwtSessionService jwtSessionService;
-    private final JwtSessionRepository jwtSessionRepository;
-    private final UserRepository userRepository;
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final SecureRandom secureRandom = new SecureRandom();
+  private final static String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345678";
 
-    // 비밀번호 초기화
-    @Override
-    public void resetPassword(String email) {
+  @Value("${resetpassword.validity-seconds}")
+  private long PASSWORD_VALIDITY_SECONDS;
 
+  // 비밀번호 초기화
+  @Transactional
+  @Override
+  public void resetPassword(ResetPasswordRequest resetPasswordRequest) {
+    String email = resetPasswordRequest.email();
+    
+    // TODO: 이메일 전송 로직 추가
+
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new UserNotFoundException());
+
+    // 임시 비밀번호
+    String tempPassword = generateTempPassword();
+    String encodedTempPassword = passwordEncoder.encode(tempPassword);
+
+    // DB 업데이트
+    user.setTempPassword(encodedTempPassword, Instant.now().plusSeconds(PASSWORD_VALIDITY_SECONDS));
+
+    log.info("임시 비밀번호: {}", tempPassword);
+  }
+
+  // 임시 비밀번호 생성
+  // 8자리, 영문, 숫자
+  private String generateTempPassword() {
+    StringBuffer stringBuffer = new StringBuffer();
+    for (int i = 0; i < 8; i++) {
+      // 무작위 인덱스 반환
+      int index = secureRandom.nextInt(CHARS.length());
+      stringBuffer.append(CHARS.charAt(index));
     }
+    return stringBuffer.toString();
+  }
+
 }

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/CustomUserDetails.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/CustomUserDetails.java
@@ -1,56 +1,70 @@
 package com.codeit.weatherwear.domain.security.customauthentication;
 
 import com.codeit.weatherwear.domain.user.entity.Role;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+@Slf4j
 public class CustomUserDetails implements UserDetails {
 
-    private final UUID userID;
-    private final String email;
-    private final String password;
+  private final UUID userID;
+  private final String email;
+  private final String password;
 
-    private final Role role;
-    private final boolean locked;
+  private final Role role;
+  private final boolean locked;
+  private final Instant tempPasswordExpirationTime;
 
-    public CustomUserDetails(UUID userId, String email, String password, Role role,
-        boolean locked) {
-        this.userID = userId;
-        this.email = email;
-        this.password = password;
-        this.role = role;
-        this.locked = locked;
+  public CustomUserDetails(UUID userId, String email, String password, Role role,
+      boolean locked, Instant tempPasswordExpirationTime) {
+    this.userID = userId;
+    this.email = email;
+    this.password = password;
+    this.role = role;
+    this.locked = locked;
+    this.tempPasswordExpirationTime = tempPasswordExpirationTime;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    List<GrantedAuthority> authorities = List.of(
+        new SimpleGrantedAuthority("ROLE_" + this.role.name()));
+    return authorities;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  // email + password로 로그인하므로 name 대신 email을 return
+  @Override
+  public String getUsername() {
+    return email;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return !locked;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    if (tempPasswordExpirationTime != null && tempPasswordExpirationTime.isBefore(Instant.now())) {
+      log.info("만료된 임시 비밀번호");
+      return false;
     }
+    return true;
+  }
 
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        List<GrantedAuthority> authorities = List.of(
-            new SimpleGrantedAuthority("ROLE_" + this.role.name()));
-        return authorities;
-    }
-
-    @Override
-    public String getPassword() {
-        return password;
-    }
-
-    // email + password로 로그인하므로 name 대신 email을 return
-    @Override
-    public String getUsername() {
-        return email;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return !locked;
-    }
-
-    public UUID getUserId() {
-        return this.userID;
-    }
+  public UUID getUserId() {
+    return this.userID;
+  }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/CustomUserDetailsService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/CustomUserDetailsService.java
@@ -11,28 +11,29 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final UserRepository userRepository;
+  private final UserRepository userRepository;
 
 
-    /**
-     * 로그인 시 email+password로 로그인하므로 email 기준으로 유저를 찾음
-     *
-     * @param email
-     * @return UserDetails
-     * @throws UsernameNotFoundException
-     */
-    @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return userRepository.findByEmail(email)
-            .map(user -> new CustomUserDetails(
-                user.getId(),
-                user.getEmail(),
-                user.getPassword(),
-                user.getRole(),
-                user.isLocked())
-            )
-            .orElseThrow(
-                () -> new UsernameNotFoundException("User not found with email: " + email));
+  /**
+   * 로그인 시 email+password로 로그인하므로 email 기준으로 유저를 찾음
+   *
+   * @param email
+   * @return UserDetails
+   * @throws UsernameNotFoundException
+   */
+  @Override
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    return userRepository.findByEmail(email)
+        .map(user -> new CustomUserDetails(
+            user.getId(),
+            user.getEmail(),
+            user.getPassword(),
+            user.getRole(),
+            user.isLocked(),
+            user.getTempPasswordExpirationTime())
+        )
+        .orElseThrow(
+            () -> new UsernameNotFoundException("User not found with email: " + email));
 
-    }
+  }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/jwt/JwtAuthenticationFilter.java
@@ -28,64 +28,65 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final JwtSessionService jwtSessionService;
-    private final UserRepository userRepository;
+  private final JwtSessionService jwtSessionService;
+  private final UserRepository userRepository;
 
-    private final ObjectMapper objectMapper;
-    private static final String BEARER_PREFIX = "Bearer ";
+  private final ObjectMapper objectMapper;
+  private static final String BEARER_PREFIX = "Bearer ";
 
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-        FilterChain filterChain) throws ServletException, IOException {
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
 
-        // Authorization 헤더에서 jwt access token 추출
-        String token = extractTokenFromHeader(request);
+    // Authorization 헤더에서 jwt access token 추출
+    String token = extractTokenFromHeader(request);
 
-        // 토큰 유효성 & 로그인 상태 검증
-        if (token != null && jwtSessionService.isValidToken(token) && jwtSessionService.isSignedIn(
-            token)) {
-            // 인증 처리
-            UUID userId = jwtSessionService.extractUserId(token);
+    // 토큰 유효성 & 로그인 상태 검증
+    if (token != null && jwtSessionService.isValidToken(token) && jwtSessionService.isSignedIn(
+        token)) {
+      // 인증 처리
+      UUID userId = jwtSessionService.extractUserId(token);
 
-            User user = userRepository.findById(userId).orElseThrow(
-                () -> new UsernameNotFoundException("User not found with id: " + userId));
-            CustomUserDetails userDetails = new CustomUserDetails(
-                userId,
-                user.getEmail(),
-                user.getPassword(),
-                user.getRole(),
-                user.isLocked()
-            );
-            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
-                userDetails, null, userDetails.getAuthorities());
-            SecurityContextHolder.getContext().setAuthentication(auth);
-            // 필터 처리 계속
-            filterChain.doFilter(request, response);
+      User user = userRepository.findById(userId).orElseThrow(
+          () -> new UsernameNotFoundException("User not found with id: " + userId));
+      CustomUserDetails userDetails = new CustomUserDetails(
+          userId,
+          user.getEmail(),
+          user.getPassword(),
+          user.getRole(),
+          user.isLocked(),
+          user.getTempPasswordExpirationTime()
+      );
+      UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+          userDetails, null, userDetails.getAuthorities());
+      SecurityContextHolder.getContext().setAuthentication(auth);
+      // 필터 처리 계속
+      filterChain.doFilter(request, response);
 
-        } else if (token != null) {
-            // 잘못된 토큰 & 비로그인 상태 -> 401 응답
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json");
-            response.setCharacterEncoding("UTF-8");
-            ErrorResponse errorResponse = new ErrorResponse("JwtValidationException", null, null);
-            objectMapper.writeValue(response.getWriter(), errorResponse);
-        } else {
-            // 토큰이 없는 경우
-            // TODO: 인증이 필요없는 경로면 다음 필터 진행, 아니면 401 응답
-            filterChain.doFilter(request, response);
-        }
-
+    } else if (token != null) {
+      // 잘못된 토큰 & 비로그인 상태 -> 401 응답
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      response.setContentType("application/json");
+      response.setCharacterEncoding("UTF-8");
+      ErrorResponse errorResponse = new ErrorResponse("JwtValidationException", null, null);
+      objectMapper.writeValue(response.getWriter(), errorResponse);
+    } else {
+      // 토큰이 없는 경우
+      // TODO: 인증이 필요없는 경로면 다음 필터 진행, 아니면 401 응답
+      filterChain.doFilter(request, response);
     }
 
-    private String extractTokenFromHeader(HttpServletRequest request) {
-        // AUTHORIZATION 헤더에서 추출
-        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
-        // "Bearer " 제거
-        if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken.substring(BEARER_PREFIX.length());
-        }
-        return null;
+  }
+
+  private String extractTokenFromHeader(HttpServletRequest request) {
+    // AUTHORIZATION 헤더에서 추출
+    String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+    // "Bearer " 제거
+    if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
+      return bearerToken.substring(BEARER_PREFIX.length());
     }
+    return null;
+  }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/user/entity/User.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/entity/User.java
@@ -38,114 +38,127 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EqualsAndHashCode(of = "email")
 public class User {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(updatable = false)
-    private UUID id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  @Column(updatable = false)
+  private UUID id;
 
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private Instant createdAt;
+  @CreatedDate
+  @Column(name = "created_at", updatable = false)
+  private Instant createdAt;
 
-    @LastModifiedDate
-    @Column(name = "updated_at", updatable = true)
-    private Instant updatedAt;
+  @LastModifiedDate
+  @Column(name = "updated_at", updatable = true)
+  private Instant updatedAt;
 
-    @Column(nullable = false, unique = true)
-    private String email;
+  @Column(nullable = false, unique = true)
+  private String email;
 
-    @Column(nullable = false, unique = true)
-    private String name;
+  @Column(nullable = false, unique = true)
+  private String name;
 
-    @Column(nullable = false)
-    private String password;
+  @Column(nullable = false)
+  private String password;
 
-    @Enumerated(EnumType.STRING)
-    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
-    @Column(nullable = false)
-    private Role role = Role.USER;
+  @Enumerated(EnumType.STRING)
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+  @Column(nullable = false)
+  private Role role = Role.USER;
 
-    @Column(nullable = false)
-    private boolean locked = false;
+  @Column(nullable = false)
+  private boolean locked = false;
 
-    @Enumerated(EnumType.STRING)
-    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
-    private Gender gender;
+  @Enumerated(EnumType.STRING)
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+  private Gender gender;
 
-    @Column(name = "birth_date")
-    private LocalDate birthDate;
+  @Column(name = "birth_date")
+  private LocalDate birthDate;
 
-    @Column(name = "temperature_sensitivity")
-    private Integer temperatureSensitivity;
+  @Column(name = "temperature_sensitivity")
+  private Integer temperatureSensitivity;
 
-    @Column(name = "profile_image_url")
-    private String profileImageUrl;
+  @Column(name = "profile_image_url")
+  private String profileImageUrl;
 
-    @Type(JsonType.class)
-    @Column(name = "linked_oauth_providers", columnDefinition = "jsonb")
-    private List<OAuthProvider> linkedOAuthProviders;
+  @Type(JsonType.class)
+  @Column(name = "linked_oauth_providers", columnDefinition = "jsonb")
+  private List<OAuthProvider> linkedOAuthProviders;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "location_id")
-    private Location location;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "location_id")
+  private Location location;
 
-    @Builder
-    private User(UUID id, String email, String name, String password,
-        Role role, boolean locked, Gender gender, LocalDate birthDate,
-        Integer temperatureSensitivity, String profileImageUrl,
-        List<OAuthProvider> linkedOAuthProviders,
-        Location location, Instant createdAt, Instant updatedAt) {
-        this.id = id;
-        this.email = email;
-        this.name = name;
-        this.password = password;
-        this.role = role == null ? Role.USER : role;
-        this.locked = locked;
-        this.gender = gender;
-        this.birthDate = birthDate;
-        this.temperatureSensitivity = temperatureSensitivity;
-        this.profileImageUrl = profileImageUrl;
-        this.linkedOAuthProviders = linkedOAuthProviders;
-        this.location = location;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
+  @Column(nullable = true)
+  private Instant tempPasswordExpirationTime;
+
+  @Builder
+  private User(UUID id, String email, String name, String password,
+      Role role, boolean locked, Gender gender, LocalDate birthDate,
+      Integer temperatureSensitivity, String profileImageUrl,
+      List<OAuthProvider> linkedOAuthProviders,
+      Location location, Instant createdAt, Instant updatedAt,
+      Instant tempPasswordExpirationTime) {
+    this.id = id;
+    this.email = email;
+    this.name = name;
+    this.password = password;
+    this.role = role == null ? Role.USER : role;
+    this.locked = locked;
+    this.gender = gender;
+    this.birthDate = birthDate;
+    this.temperatureSensitivity = temperatureSensitivity;
+    this.profileImageUrl = profileImageUrl;
+    this.linkedOAuthProviders = linkedOAuthProviders;
+    this.location = location;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.tempPasswordExpirationTime = tempPasswordExpirationTime;
+  }
+
+  public void updateProfile(String name, Gender gender, LocalDate birthDate, Location location,
+      Integer temperatureSensitivity, String profileImageUrl) {
+    if (name != null) {
+      this.name = name;
     }
-
-    public void updateProfile(String name, Gender gender, LocalDate birthDate, Location location,
-        Integer temperatureSensitivity, String profileImageUrl) {
-        if (name != null) {
-            this.name = name;
-        }
-        if (gender != null) {
-            this.gender = gender;
-        }
-        if (birthDate != null) {
-            this.birthDate = birthDate;
-        }
-        if (location != null) {
-            this.location = location;
-        }
-        if (temperatureSensitivity != null) {
-            this.temperatureSensitivity = temperatureSensitivity;
-        }
-        if (profileImageUrl != null) {
-            this.profileImageUrl = profileImageUrl;
-        }
+    if (gender != null) {
+      this.gender = gender;
     }
-
-    public void updateLocked(boolean locked) {
-        this.locked = locked;
+    if (birthDate != null) {
+      this.birthDate = birthDate;
     }
-
-    public void updatePassword(String password) {
-        if (password != null && !password.isBlank()) {
-            this.password = password;
-        }
+    if (location != null) {
+      this.location = location;
     }
-
-    public void updateRole(Role role) {
-        if (role != null) {
-            this.role = role;
-        }
+    if (temperatureSensitivity != null) {
+      this.temperatureSensitivity = temperatureSensitivity;
     }
+    if (profileImageUrl != null) {
+      this.profileImageUrl = profileImageUrl;
+    }
+  }
+
+  public void updateLocked(boolean locked) {
+    this.locked = locked;
+  }
+
+  public void updatePassword(String password) {
+    if (password != null && !password.isBlank()) {
+      this.password = password;
+      this.tempPasswordExpirationTime = null;   // 정식으로 비밀번호 변경된 경우 다시 null로 설정
+    }
+  }
+
+  public void updateRole(Role role) {
+    if (role != null) {
+      this.role = role;
+    }
+  }
+
+  public void setTempPassword(String password, Instant tempPasswordExpirationTime) {
+    if (password != null && !password.isBlank()) {
+      this.password = password;
+      this.tempPasswordExpirationTime = tempPasswordExpirationTime;
+    }
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,18 @@ spring:
 
   config:
     import: optional:file:.env[.properties]
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true
 
 server:
   shutdown: graceful

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,7 @@ jwt:
 
 time:
   zone-id: ${TIME_ZONE_ID:Asia/Seoul}
+
+
+resetpassword:
+  validity-seconds: 600 # 10분


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#73 
#83 PR에 이어 작업

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev
feat/73/auth-api -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- POST /api/auth/reset-password API 구현
  - 비밀번호 초기화 요청입니다.
  - 이메일을 입력하면 해당 이메일로 임시 비밀번호가 발급됩니다.
  - 임시 비밀번호는 10분 간 유효합니다.
  
### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

다음 사항들을 포스트맨으로 테스트하고 DB 데이터도 확인하였습니다.
- 임시 비밀번호 발급 요청
  - 유저가 있는 경우 성공적으로 발급
  - 유저가 없는 경우 404
- 임시 비밀번호로 로그인
- 임시 비밀번호 발급 후 만료시간(10분) 지나면 로그인 불가

![image](https://github.com/user-attachments/assets/d49863e4-7549-43f5-b09a-5db5f7087659)

![image](https://github.com/user-attachments/assets/44486e5c-2580-4be1-b97d-253892185bda)


### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

---

### ⭐ 추가 코멘트

- 7/1에 코드스타일 다시 맞추고 그로 인해 변경된 부분이 많습니다! 죄송합니다 🙇‍♀️🙇‍♀️

- JavaMailSender 라이브러리를 처음 써봐서 꽤 흥미로웠습니다. 추후 이 기능 관련 자료를 작성해보려 합니다.

- 포스트맨으로 테스트 시 메일 전송까지 하여 응답까지 4-5s가 소요됐습니다. 리팩토링 단계에서 비동기를 도입해봐야겠습니다.

- 이메일은 다음과 같이 옵니다.
![image](https://github.com/user-attachments/assets/e255cb38-82f0-4a45-933c-333bb8f8060e)


- 공유자료를 업데이트했습니다.
  - 유효한 임시 비밀번호로 로그인을 하는지 확인하기 위한 컬럼 temp_password_expiration_time이 추가됐습니다. 
    - https://www.notion.so/SQL-Query-21b97c15da088020bccfd214cdfd2a0a에 업데이트했습니다.
  - 구글 계정을 새롭게 설정했습니다.
    - https://www.notion.so/22497c15da0880158b02f9236e7aa1a4 을 참고하시기 바랍니다.
  - 환경변수가 추가됐습니다. 이메일 전송을 위한 환경변수입니다.
    - https://www.notion.so/env-env-dev-env-prod-env-test-21b97c15da0880d8bdefe80a6316f1d4

### 고민거리

요구사항 중 다음과 같은 내용이 있습니다.
"임시 비밀번호로 로그인 시 새 비밀번호로 변경해야 한다."

제가 처음 생각한 아이디어는 이런데..
- 임시 비밀번호로 로그인 성공한 경우 응답 response body에 "must change password" 같이 프론트에게 특정한 메시지를 전송하여 비밀번호 변경 페이지로 리다이렉트를 유도

스웨거로 보아 프론트에서는 이런 상황을 전혀 고려하지 않는 듯하고,
애초에 비밀번호 변경 페이지가 구현되지 않았습니다! 오직 백엔드에서 구현한 PATCH API만 있습니다.

그래서 결국 이메일 본문에 "로그인 후 반드시 비밀번호를 변경해주세요."라는 문구를 넣는 정도로만 해봤습니다.
사실 이것도 사용자가 비밀번호를 변경할 수 있는 방법이 없으니 무의미하긴 합니다...

어떻게 하면 좋을까요?
