### PR TITLE
Refactor:옷,속성 커스텀에러,로그 적용 & 조회 테스트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ out/
 
 ### SQL 파일 ###
 *.sql*
+
+### macOS 시스템 파일 무시 ###
+.DS_Store
+**/.DS_Store

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/controller/AttributeController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/controller/AttributeController.java
@@ -10,6 +10,7 @@ import com.codeit.weatherwear.global.response.PageResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/clothes/attribute-defs")
@@ -31,13 +33,15 @@ public class AttributeController implements AttributeApi {
     /**
      * 새로운 의상 속성을 등록합니다.
      *
-     * @param dto 속성 정보(이름, 후보값들)
+     * @param request 속성 정보(이름, 후보값들)
      * @return 201 400
      */
     @Override
     @PostMapping
-    public ResponseEntity<ClothesAttributeDefDto> create(@Valid @RequestBody ClothesAttributeDefCreateRequest dto) {
-        ClothesAttributeDefDto createAttribute = service.create(dto);
+    public ResponseEntity<ClothesAttributeDefDto> create(@Valid @RequestBody ClothesAttributeDefCreateRequest request) {
+        log.info("[속성 정의 등록 요청] 속성명: {}", request.name());
+
+        ClothesAttributeDefDto createAttribute = service.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(createAttribute);
     }
 
@@ -52,6 +56,8 @@ public class AttributeController implements AttributeApi {
     public ResponseEntity<ClothesAttributeDefDto> update(
         @PathVariable UUID definitionId,
         @Valid @RequestBody ClothesAttributeDefUpdateRequest request) {
+        log.info("[속성 정의 수정 요청] ID: {}, 속성명: {}", definitionId, request.name());
+
         ClothesAttributeDefDto updateAttribute = service.update(definitionId, request);
         return ResponseEntity.status(HttpStatus.OK).body(updateAttribute);
     }
@@ -65,6 +71,7 @@ public class AttributeController implements AttributeApi {
     @Override
     @DeleteMapping("/{definitionId}")
     public ResponseEntity<Void> delete(@PathVariable UUID definitionId) {
+        log.info("[속성 정의 삭제 요청] ID: {}", definitionId);
         service.delete(definitionId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
@@ -79,6 +86,9 @@ public class AttributeController implements AttributeApi {
     @GetMapping
     public ResponseEntity<PageResponse<ClothesAttributeDefDto>> searchAttributes(
         @ModelAttribute @Valid AttributesSearchRequest request) {
+        log.info("[속성 정의 목록 조회 요청] keyword: {}, sortBy: {}, direction: {}, limit: {}",
+            request.keywordLike(), request.sortBy(), request.sortDirection(), request.limit());
+
         PageResponse<ClothesAttributeDefDto> result = service.searchAttributes(request);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/controller/ClothController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/controller/ClothController.java
@@ -10,6 +10,7 @@ import com.codeit.weatherwear.global.response.PageResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/clothes")
@@ -41,6 +43,8 @@ public class ClothController implements ClothApi {
     public ResponseEntity<ClothesDto> create(
         @Valid @RequestPart("request") ClothesCreateRequest request,
         @RequestPart(value="image",required = false) MultipartFile image) {
+        log.info("[옷 등록 요청] 옷 이름: {}, 의상 타입: {}", request.name(), request.type());
+
         ClothesDto createClothes = clothService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(createClothes);
     }
@@ -54,6 +58,9 @@ public class ClothController implements ClothApi {
     @Override
     public ResponseEntity<PageResponse<ClothesDto>> searchClothes(
         @ModelAttribute @Valid ClothesSearchRequest request) {
+        log.info("[옷 목록 조회 요청] ownerId: {}, typeEqual: {}, limit: {}",
+            request.ownerId(),request.typeEqual(), request.limit());
+
         PageResponse<ClothesDto> result = clothService.searchClothes(request);
         return ResponseEntity.ok(result);
     }
@@ -75,6 +82,8 @@ public class ClothController implements ClothApi {
         @PathVariable("clothesId") UUID clothesId,
         @Valid @RequestPart("request") ClothesUpdateRequest request,
         @RequestPart(value = "image",required = false) MultipartFile image) {
+        log.info("[옷 수정 요청] ID: {}, 옷 이름: {}", clothesId, request.name());
+
         ClothesDto update = clothService.update(clothesId, request);
         return ResponseEntity.ok(update);
     }
@@ -88,6 +97,8 @@ public class ClothController implements ClothApi {
     @Override
     @DeleteMapping("/{clothesId}")
     public ResponseEntity<Void> delete(@PathVariable UUID clothesId) {
+        log.info("[옷 삭제 요청] ID: {}", clothesId);
+
         clothService.delete(clothesId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/entity/Attribute.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/entity/Attribute.java
@@ -1,5 +1,7 @@
 package com.codeit.weatherwear.domain.clothes.entity;
 
+import com.codeit.weatherwear.domain.clothes.exception.InvalidAttributeNameException;
+import com.codeit.weatherwear.domain.clothes.exception.SelectableDuplicateException;
 import com.vladmihalcea.hibernate.type.json.JsonType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -55,15 +57,7 @@ public class Attribute {
     }
 
     public void update(String name, List<String> selectableValues) {
-        if (!this.name.equals(name)) {
-            throw new IllegalArgumentException("해당 속성명이 일치하지 않습니다.");
-        }
-        List<String> values = selectableValues;
-        if(values.size() != values.stream().distinct().count()) {
-            throw new IllegalArgumentException("중복 선택값이 존재합니다.");
-        }
-
         this.selectableValues.clear();
-        this.selectableValues=new ArrayList<>(values);
+        this.selectableValues=new ArrayList<>(selectableValues);
     }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/entity/ClothWithAttributes.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/entity/ClothWithAttributes.java
@@ -38,6 +38,7 @@ public class ClothWithAttributes {
     @Column(updatable = true)
     private Instant updatedAt;
 
+    @Column(name = "\"value\"")
     private String value;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -64,3 +65,4 @@ public class ClothWithAttributes {
         this.cloth = cloth;
     }
 }
+

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/exception/AttributeAlreadyExistsException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/exception/AttributeAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.domain.clothes.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+
+public class AttributeAlreadyExistsException extends CustomException {
+
+  public AttributeAlreadyExistsException() {
+    super(ErrorCode.ATTRIBUTE_ALREADY_EXISTS);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/exception/AttributeNotFoundException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/exception/AttributeNotFoundException.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.domain.clothes.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+
+public class AttributeNotFoundException extends CustomException {
+
+  public AttributeNotFoundException() {
+    super(ErrorCode.ATTRIBUTE_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/exception/ClothAlreadyExistsException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/exception/ClothAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.domain.clothes.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+
+public class ClothAlreadyExistsException extends CustomException {
+
+  public ClothAlreadyExistsException() {
+    super(ErrorCode.CLOTH_ALREADY_EXISTS);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/exception/ClothNotFoundException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/exception/ClothNotFoundException.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.domain.clothes.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+
+public class ClothNotFoundException extends CustomException {
+
+  public ClothNotFoundException() {
+    super(ErrorCode.CLOTH_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/exception/InvalidAttributeNameException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/exception/InvalidAttributeNameException.java
@@ -1,0 +1,12 @@
+package com.codeit.weatherwear.domain.clothes.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+
+public class InvalidAttributeNameException extends CustomException {
+
+
+  public InvalidAttributeNameException() {
+    super(ErrorCode.INVALID_ATTRIBUTE_NAME);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/exception/SelectableDuplicateException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/exception/SelectableDuplicateException.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.domain.clothes.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+
+public class SelectableDuplicateException extends CustomException {
+
+  public SelectableDuplicateException() {
+    super(ErrorCode.SELECTABLE_DUPLICATE);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/AttributeServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/AttributeServiceImpl.java
@@ -18,10 +18,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -40,19 +42,23 @@ public class AttributeServiceImpl implements AttributeService {
     @Transactional
     public ClothesAttributeDefDto create(ClothesAttributeDefCreateRequest request) {
         if (attributeRepository.existsByName(request.name())) {
+            log.warn("[속성 정의 등록 실패] 이미 존재하는 속성명 : {}", request.name());
             throw new AttributeAlreadyExistsException();
         }
         Set<String> uniqueValues = new HashSet<>(request.selectValues());
         if (uniqueValues.size() != request.selectValues().size()) {
+            log.warn("[속성 정의 등록 실패] 중복된 속성값: {}", request.selectValues());
             throw new SelectableDuplicateException();
         }
 
-        Attribute attributes = Attribute.builder()
+        Attribute attribute = Attribute.builder()
             .name(request.name())
             .selectableValues(request.selectValues())
             .build();
 
-        Attribute save = attributeRepository.save(attributes);
+        Attribute save = attributeRepository.save(attribute);
+        log.info("[속성 정의 등록 완료] id: {}, 속성명: {}", attribute.getId(), attribute.getName());
+
         return attributeMapper.toDto(save);
     }
 
@@ -67,17 +73,25 @@ public class AttributeServiceImpl implements AttributeService {
     @Transactional
     public ClothesAttributeDefDto update(UUID id, ClothesAttributeDefUpdateRequest request) {
         Attribute attribute = attributeRepository.findById(id)
-            .orElseThrow(AttributeNotFoundException::new);
+            .orElseThrow(()->{
+                log.warn("[속성 정의 수정 실패] 존재하지 않는 속성입니다. ID : {}", id);
+                return new AttributeNotFoundException();
+            });
         if(!attribute.getName().equals(request.name())) {
+            log.warn("[속성 정의 수정 실패] 존재하지 않는 속성명이거나 속성명 요청이 잘못되었습니다. ID : {}", id);
             throw new InvalidAttributeNameException();
         }
 
         List<String> values = request.selectValues();
         if(values.size() != values.stream().distinct().count()) {
+            log.warn("[속성 정의 수정 실패] 중복된 속성 값들을 입력하였습니다. ID : {}", id);
             throw new SelectableDuplicateException();
         }
 
+        log.debug("[속성 정의 수정] name: {}, 변경 전 values: {}", attribute.getName(), attribute.getSelectableValues());
         attribute.update(request.name(), values);
+
+        log.info("[속성 정의 수정 완료] ID : {}, name: {}, values: {}", id, attribute.getName(), attribute.getSelectableValues());
         return attributeMapper.toDto(attribute);
     }
 
@@ -89,9 +103,12 @@ public class AttributeServiceImpl implements AttributeService {
     @Override
     @Transactional
     public void delete(UUID id) {
-        Attribute attributes = attributeRepository.findById(id)
-            .orElseThrow(AttributeNotFoundException::new);
-        attributeRepository.deleteById(attributes.getId());
+        Attribute attribute = attributeRepository.findById(id).orElseThrow(()->{
+                log.warn("[속성 정의 삭제 실패] 존재하지 않는 속성 ID: {}", id);
+                throw new AttributeNotFoundException();
+        });
+        attributeRepository.deleteById(attribute.getId());
+        log.info("[속성 정의 삭제 완료] ID: {}", id);
     }
 
     /**
@@ -110,11 +127,14 @@ public class AttributeServiceImpl implements AttributeService {
 
         Slice<Attribute> attributes = attributeRepository.searchAttributes(cursor, idAfter, limit,
             sortBy, sortDirection, keywordLike);
-
         List<Attribute> attributesList = attributes.getContent();
+
+        log.debug("[쿼리 실행 결과] 전체 개수: {}, hasNext: {}", attributesList.size(), attributes.hasNext());
+
         List<ClothesAttributeDefDto> result = attributesList.stream()
             .map(attributeMapper::toDto)
             .toList();
+        log.debug("[응답 변환] 변환된 ClothesAttributeDefDto 개수: {}", result.size());
 
         Attribute last =
             (attributesList.size() > 0) ? attributesList.get(attributesList.size() - 1) : null;
@@ -142,6 +162,8 @@ public class AttributeServiceImpl implements AttributeService {
             sortBy,
             sortDirection.name()
         );
+
+
     }
 
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/AttributeServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/AttributeServiceImpl.java
@@ -5,6 +5,10 @@ import com.codeit.weatherwear.domain.clothes.dto.request.ClothesAttributeDefCrea
 import com.codeit.weatherwear.domain.clothes.dto.request.ClothesAttributeDefUpdateRequest;
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesAttributeDefDto;
 import com.codeit.weatherwear.domain.clothes.entity.Attribute;
+import com.codeit.weatherwear.domain.clothes.exception.AttributeAlreadyExistsException;
+import com.codeit.weatherwear.domain.clothes.exception.AttributeNotFoundException;
+import com.codeit.weatherwear.domain.clothes.exception.InvalidAttributeNameException;
+import com.codeit.weatherwear.domain.clothes.exception.SelectableDuplicateException;
 import com.codeit.weatherwear.domain.clothes.mapper.AttributeMapper;
 import com.codeit.weatherwear.domain.clothes.repository.AttributeRepository;
 import com.codeit.weatherwear.global.request.SortDirection;
@@ -36,11 +40,11 @@ public class AttributeServiceImpl implements AttributeService {
     @Transactional
     public ClothesAttributeDefDto create(ClothesAttributeDefCreateRequest request) {
         if (attributeRepository.existsByName(request.name())) {
-            throw new IllegalArgumentException("이미 등록된 속성입니다.");
+            throw new AttributeAlreadyExistsException();
         }
         Set<String> uniqueValues = new HashSet<>(request.selectValues());
         if (uniqueValues.size() != request.selectValues().size()) {
-            throw new IllegalArgumentException("중복된 값이 입력되었습니다.");
+            throw new SelectableDuplicateException();
         }
 
         Attribute attributes = Attribute.builder()
@@ -62,10 +66,19 @@ public class AttributeServiceImpl implements AttributeService {
     @Override
     @Transactional
     public ClothesAttributeDefDto update(UUID id, ClothesAttributeDefUpdateRequest request) {
-        Attribute attributes = attributeRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 속성입니다"));
-        attributes.update(request.name(), request.selectValues());
-        return attributeMapper.toDto(attributes);
+        Attribute attribute = attributeRepository.findById(id)
+            .orElseThrow(AttributeNotFoundException::new);
+        if(!attribute.getName().equals(request.name())) {
+            throw new InvalidAttributeNameException();
+        }
+
+        List<String> values = request.selectValues();
+        if(values.size() != values.stream().distinct().count()) {
+            throw new SelectableDuplicateException();
+        }
+
+        attribute.update(request.name(), values);
+        return attributeMapper.toDto(attribute);
     }
 
     /**
@@ -77,7 +90,7 @@ public class AttributeServiceImpl implements AttributeService {
     @Transactional
     public void delete(UUID id) {
         Attribute attributes = attributeRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 속성입니다"));
+            .orElseThrow(AttributeNotFoundException::new);
         attributeRepository.deleteById(attributes.getId());
     }
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -10,6 +10,8 @@ import com.codeit.weatherwear.domain.clothes.entity.Cloth;
 
 import com.codeit.weatherwear.domain.clothes.entity.ClothType;
 import com.codeit.weatherwear.domain.clothes.entity.ClothWithAttributes;
+import com.codeit.weatherwear.domain.clothes.exception.AttributeNotFoundException;
+import com.codeit.weatherwear.domain.clothes.exception.ClothNotFoundException;
 import com.codeit.weatherwear.domain.clothes.mapper.ClothMapper;
 import com.codeit.weatherwear.domain.clothes.repository.AttributeRepository;
 import com.codeit.weatherwear.domain.clothes.repository.ClothRepository;
@@ -85,8 +87,8 @@ public class ClothServiceImpl implements ClothService {
      */
     @Override
     public ClothesDto update(UUID clothesId,ClothesUpdateRequest request) {
-        Cloth cloth = clothRepository.findByIdWithAttributes(clothesId)
-            .orElseThrow(() -> new IllegalArgumentException("의상을 찾을 수 없습니다"));
+        Cloth cloth = clothRepository.findById(clothesId)
+            .orElseThrow(ClothNotFoundException::new);
 
         List<UUID> attrIds = request.attributes().stream()
             .map(ClothesAttributeDto::definitionId)
@@ -161,7 +163,7 @@ public class ClothServiceImpl implements ClothService {
     @Override
     public void delete(UUID clothesId) {
         Cloth cloth = clothRepository.findById(clothesId)
-            .orElseThrow(()->new IllegalArgumentException("의상을 찾을 수 없습니다"));
+            .orElseThrow(ClothNotFoundException::new);
         clothRepository.delete(cloth);
     }
 
@@ -171,7 +173,7 @@ public class ClothServiceImpl implements ClothService {
         for (ClothesAttributeDto dto : attributeDtos) {
             Attribute attribute = attrMap.get(dto.definitionId());
             if (attribute == null) {
-                throw new IllegalArgumentException("존재하지 않는 속성입니다.");
+                throw new AttributeNotFoundException();
             }
             if(!attribute.getSelectableValues().contains(dto.value())) {
                 throw new IllegalArgumentException("선택한 속성 값이 존재하지 않습니다.");

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -93,7 +93,7 @@ public class ClothServiceImpl implements ClothService {
      */
     @Override
     public ClothesDto update(UUID clothesId,ClothesUpdateRequest request) {
-        Cloth cloth = clothRepository.findById(clothesId)
+        Cloth cloth = clothRepository.findByIdWithAttributes(clothesId)
             .orElseThrow(()->{
                 log.warn("[옷 수정 실패] id: {}, 수정 요청한 옷 이름: {}", clothesId, request.name());
                 return new ClothNotFoundException();
@@ -137,7 +137,7 @@ public class ClothServiceImpl implements ClothService {
         List<Cloth> clothesList = clothes.getContent();
         log.debug("[쿼리 실행 결과] 전체 개수: {}, hasNext: {}", clothesList.size(), clothes.hasNext());
 
-        //toDto : N+1문제위해 한번에 갖고오기
+        //toDto : N+1문제 해결위해 한번에 갖고오기
         List<UUID> ids = clothesList.stream()
             .map(Cloth::getId)
             .toList();

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -12,6 +12,7 @@ import com.codeit.weatherwear.domain.clothes.entity.ClothType;
 import com.codeit.weatherwear.domain.clothes.entity.ClothWithAttributes;
 import com.codeit.weatherwear.domain.clothes.exception.AttributeNotFoundException;
 import com.codeit.weatherwear.domain.clothes.exception.ClothNotFoundException;
+import com.codeit.weatherwear.domain.clothes.exception.InvalidAttributeNameException;
 import com.codeit.weatherwear.domain.clothes.mapper.ClothMapper;
 import com.codeit.weatherwear.domain.clothes.repository.AttributeRepository;
 import com.codeit.weatherwear.domain.clothes.repository.ClothRepository;
@@ -29,10 +30,12 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -53,7 +56,10 @@ public class ClothServiceImpl implements ClothService {
     public ClothesDto create(ClothesCreateRequest request) {
         //사용자 찾기
         User user = userRepository.findById(request.ownerId())
-            .orElseThrow(UserNotFoundException::new);
+            .orElseThrow(()-> {
+                log.warn("[옷 등록 실패] 존재하지 않는 사용자 : {}", request.ownerId());
+              return new UserNotFoundException();
+            });
 
         List<UUID> attributesIds = request.attributes().stream()
             .map(ClothesAttributeDto::definitionId).toList();
@@ -74,7 +80,7 @@ public class ClothServiceImpl implements ClothService {
         applyAttributesToCloth(request.attributes(), attrMap, cloth);
 
         Cloth saveCloth = clothRepository.save(cloth);
-
+        log.info("[옷 등록 완료] id: {}, 옷 이름: {}", saveCloth.getId(), saveCloth.getName());
         return clothMapper.toDto(saveCloth);
     }
 
@@ -88,7 +94,10 @@ public class ClothServiceImpl implements ClothService {
     @Override
     public ClothesDto update(UUID clothesId,ClothesUpdateRequest request) {
         Cloth cloth = clothRepository.findById(clothesId)
-            .orElseThrow(ClothNotFoundException::new);
+            .orElseThrow(()->{
+                log.warn("[옷 수정 실패] id: {}, 수정 요청한 옷 이름: {}", clothesId, request.name());
+                return new ClothNotFoundException();
+            });
 
         List<UUID> attrIds = request.attributes().stream()
             .map(ClothesAttributeDto::definitionId)
@@ -102,6 +111,8 @@ public class ClothServiceImpl implements ClothService {
             .collect(Collectors.toMap(Attribute::getId, Function.identity()));
 
         applyAttributesToCloth(request.attributes(), attributeMap, cloth);
+
+        log.info("[옷 수정 완료] ID : {}, name: {}", clothesId, cloth.getName());
         return clothMapper.toDto(cloth);
     }
 
@@ -123,17 +134,19 @@ public class ClothServiceImpl implements ClothService {
         UUID ownerId=request.ownerId();
 
         Slice<Cloth> clothes = clothRepository.searchCloths(cursor,idAfter,limit,typeEqual,ownerId);
-
         List<Cloth> clothesList = clothes.getContent();
+        log.debug("[쿼리 실행 결과] 전체 개수: {}, hasNext: {}", clothesList.size(), clothes.hasNext());
 
         //toDto : N+1문제위해 한번에 갖고오기
         List<UUID> ids = clothesList.stream()
             .map(Cloth::getId)
             .toList();
         List<Cloth> clothesWithAttrs=clothRepository.findAllByIdWithAttributes(ids);
+
         List<ClothesDto> data=clothesWithAttrs.stream()
             .map(clothMapper::toDto)
             .toList();
+        log.debug("[응답 변환] 변환된 ClothesDto 개수: {}", data.size());
 
         Cloth last =
             (clothesList.size() > 0) ? clothesList.get(clothesList.size() - 1) : null;
@@ -163,8 +176,12 @@ public class ClothServiceImpl implements ClothService {
     @Override
     public void delete(UUID clothesId) {
         Cloth cloth = clothRepository.findById(clothesId)
-            .orElseThrow(ClothNotFoundException::new);
+            .orElseThrow(()->{
+                log.warn("[옷 삭제 실패] 존재하지 않는 옷 ID: {}", clothesId);
+                return new ClothNotFoundException();
+            });
         clothRepository.delete(cloth);
+        log.info("[옷 삭제 완료] ID: {}", clothesId);
     }
 
 
@@ -173,10 +190,12 @@ public class ClothServiceImpl implements ClothService {
         for (ClothesAttributeDto dto : attributeDtos) {
             Attribute attribute = attrMap.get(dto.definitionId());
             if (attribute == null) {
+                log.warn("[옷의 속성 값 적용 실패] 존재하지 않는 속성입니다. ID : {}", dto.definitionId());
                 throw new AttributeNotFoundException();
             }
             if(!attribute.getSelectableValues().contains(dto.value())) {
-                throw new IllegalArgumentException("선택한 속성 값이 존재하지 않습니다.");
+                log.warn("[옷의 속성 값 적용 실패] 존재하지 않는 속성 값입니다. ID : {}", dto.definitionId());
+                throw new InvalidAttributeNameException();
             }
 
             ClothWithAttributes attr = ClothWithAttributes.builder()
@@ -186,6 +205,7 @@ public class ClothServiceImpl implements ClothService {
                 .build();
 
             cloth.addAttribute(attr);
+            log.debug("[옷 속성 값 적용 완료]");
         }
     }
 

--- a/src/main/java/com/codeit/weatherwear/global/exception/ErrorCode.java
+++ b/src/main/java/com/codeit/weatherwear/global/exception/ErrorCode.java
@@ -36,7 +36,18 @@ public enum ErrorCode {
 
   // JWT
   JWTSESSION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증 정보 확인 실패", "토큰이 만료되거나 로그아웃되었습니다."),
-  INVALID_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT", "JWT 토큰이 손상되었거나 유효하지 않습니다.");
+  INVALID_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT", "JWT 토큰이 손상되었거나 유효하지 않습니다."),
+
+  //ATTRIBUTE
+  ATTRIBUTE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "속성 등록 실패", "속성이 이미 존재합니다."),
+  ATTRIBUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "속성 확인 실패", "존재하지 않는 속성입니다."),
+  SELECTABLE_DUPLICATE(HttpStatus.BAD_REQUEST, "속성 값 중복 등록", "중복된 속성 값이 존재합니다."),
+  INVALID_ATTRIBUTE_NAME(HttpStatus.BAD_REQUEST, "잘못된 속성명입니다.", "정보를 찾을 수 없습니다."),
+
+
+  //CLOTH
+  CLOTH_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "옷 등록 실패", "존재하는 옷입니다."),
+  CLOTH_NOT_FOUND(HttpStatus.NOT_FOUND, "옷 확인 실패", "존재하지 않는 옷입니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/test/java/com/codeit/weatherwear/domain/clothes/repository/AttributeRepositoryTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/clothes/repository/AttributeRepositoryTest.java
@@ -4,13 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.codeit.weatherwear.domain.clothes.entity.Attribute;
 import com.codeit.weatherwear.global.config.JpaConfig;
+import com.codeit.weatherwear.global.request.SortDirection;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
@@ -21,19 +27,93 @@ class AttributeRepositoryTest {
     @Autowired
     private AttributeRepository sut;
 
+    Attribute thick;
+    Attribute size;
+    Attribute touch;
+
+    @BeforeEach
+    void setUp() {
+        thick = Attribute.builder()
+            .name("두께")
+            .selectableValues(List.of("두꺼움", "얇음")).build();
+        size = Attribute.builder()
+            .name("사이즈")
+            .selectableValues(List.of("S", "L")).build();
+        touch = Attribute.builder()
+            .name("촉감")
+            .selectableValues(List.of("부드러움", "뻣뻣함")).build();
+        sut.save(thick);
+        sut.save(size);
+        sut.save(touch);
+    }
+
     @Test
     @DisplayName("저장 성공")
     void save_success() {
         //given
-        Attribute attributes = Attribute.builder()
+        Attribute attribute = Attribute.builder()
             .name("색상")
             .selectableValues(List.of("빨강", "파랑")).build();
         //when
-        Attribute result = sut.save(attributes);
+        Attribute result = sut.save(attribute);
         //then
         assertThat(result.getName()).isEqualTo("색상");
         assertThat(result.getSelectableValues()).containsExactly("빨강", "파랑");
     }
 
+    @Test
+    @DisplayName("속성 조회 성공 - hasNext = false")
+    void search_success() {
+        //given
+        int limit = 20;
 
+        //when
+        Slice<Attribute> attributeList = sut.searchAttributes(null, null, limit, "name",
+            SortDirection.DESCENDING, null);
+        List<Attribute> content = attributeList.getContent();
+
+        //then
+        assertThat(attributeList.hasNext()).isFalse();
+        assertThat(content).hasSize(3);
+        assertThat(content.get(0)).isEqualTo(touch);
+        assertThat(content.get(1)).isEqualTo(size);
+        assertThat(content.get(2)).isEqualTo(thick);
+    }
+
+    @Test
+    @DisplayName("속성 조회 성공 - hasNext=true")
+    void search_success_hasNext() {
+        //given
+        int limit = 2;
+
+        //when
+        Slice<Attribute> attributeList = sut.searchAttributes(null, null, limit, "name",
+            SortDirection.DESCENDING, null);
+        List<Attribute> content = attributeList.getContent();
+
+        //then
+        assertThat(attributeList.hasNext()).isTrue();
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0)).isEqualTo(touch);
+        assertThat(content.get(1)).isEqualTo(size);
+    }
+
+    @Test
+    @DisplayName("속성 조회 성공 - idAfter존재")
+    void search_success_cursor() {
+        //given
+        int limit = 2;
+        UUID idAfter = thick.getId();
+
+        //when
+        Slice<Attribute> attributeList = sut.searchAttributes(null, idAfter, limit, "name",
+            SortDirection.DESCENDING, null);
+        List<Attribute> content = attributeList.getContent();
+
+        //then
+        assertThat(attributeList.hasNext()).isTrue();
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0)).isEqualTo(touch);
+        assertThat(content.get(1)).isEqualTo(size);
+    }
 }

--- a/src/test/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepositoryTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepositoryTest.java
@@ -10,17 +10,20 @@ import com.codeit.weatherwear.domain.clothes.entity.ClothWithAttributes;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
 import com.codeit.weatherwear.global.config.JpaConfig;
+import java.time.Instant;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({JpaConfig.class})
+@Import(JpaConfig.class)
 public class ClothRepositoryTest {
 
     @Autowired
@@ -31,20 +34,77 @@ public class ClothRepositoryTest {
 
     @Autowired
     private AttributeRepository attributeRepository;
+    User user;
+    Cloth thinScarf;
+    Cloth whiteScarf;
+    Cloth redScarf;
+    Attribute color;
+    Attribute thick;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+            .email("user@test.com")
+            .name("user")
+            .password("user1234!")
+            .build();
+        userRepository.save(user);
+
+        color = attributeRepository.save(Attribute.builder()
+            .name("색상")
+            .selectableValues(List.of("빨강", "파랑","하양"))
+            .build());
+
+        thick = attributeRepository.save(Attribute.builder()
+            .name("두께")
+            .selectableValues(List.of("두꺼움", "얇음")).build());
+
+        ClothWithAttributes white = ClothWithAttributes.builder()
+            .value("하양")
+            .attribute(color)
+            .build();
+
+        ClothWithAttributes red = ClothWithAttributes.builder()
+            .value("빨강")
+            .attribute(color)
+            .build();
+
+        ClothWithAttributes thin = ClothWithAttributes.builder()
+            .value("얇음")
+            .attribute(thick)
+            .build();
+
+        thinScarf= Cloth.builder()
+            .name("얇은 스카프")
+            .clothType(ClothType.SCARF)
+            .user(user)
+            .build();
+        thinScarf.addAttribute(white);
+        thinScarf.addAttribute(thin);
+
+        whiteScarf= Cloth.builder()
+            .name("하얀 스카프")
+            .clothType(ClothType.SCARF)
+            .user(user)
+            .build();
+        whiteScarf.addAttribute(white);
+
+        redScarf= Cloth.builder()
+            .name("빨간 스카프")
+            .clothType(ClothType.SCARF)
+            .user(user)
+            .build();
+        redScarf.addAttribute(red);
+
+        sut.save(thinScarf);
+        sut.save(whiteScarf);
+        sut.save(redScarf);
+    }
 
     @Test
     @DisplayName("저장 성공")
     void save_success() {
         // given
-        User user = userRepository.save(User.builder()
-            .name("테스트유저")
-            .build());
-
-        Attribute color = attributeRepository.save(Attribute.builder()
-            .name("색상")
-            .selectableValues(List.of("빨강", "파랑"))
-            .build());
-
         Cloth clothes = Cloth.builder()
             .name("후드티")
             .clothType(ClothType.TOP)
@@ -68,4 +128,57 @@ public class ClothRepositoryTest {
         assertThat(saved.getClothesWithAttributes().get(0).getValue()).isEqualTo("파랑");
         assertThat(saved.getUser().getId()).isEqualTo(user.getId());
     }
+
+    @Test
+    @DisplayName("옷 조회 성공 - hasNext = false")
+    void search_success() {
+        //given
+        int limit = 20;
+
+        //when
+        Slice<Cloth> clothList = sut.searchCloths(null, null, limit, ClothType.SCARF,user.getId());
+        List<Cloth> content = clothList.getContent();
+        //then
+        assertThat(clothList.hasNext()).isFalse();
+        assertThat(content).hasSize(3);
+        assertThat(content.get(0)).isEqualTo(redScarf);
+        assertThat(content.get(1)).isEqualTo(whiteScarf);
+        assertThat(content.get(2)).isEqualTo(thinScarf);
+    }
+
+    @Test
+    @DisplayName("옷 조회 성공 - hasNext=true")
+    void search_success_hasNext() {
+        //given
+        int limit = 2;
+
+        //when
+        Slice<Cloth> clothList = sut.searchCloths(null, null, limit, ClothType.SCARF,user.getId());
+        List<Cloth> content = clothList.getContent();
+
+        //then
+        assertThat(clothList.hasNext()).isTrue();
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0)).isEqualTo(redScarf);
+        assertThat(content.get(1)).isEqualTo(whiteScarf);
+    }
+
+    @Test
+    @DisplayName("속성 조회 성공 - 커서 존재")
+    void search_success_cursor() {
+        //given
+        int limit = 2;
+        Instant cursor = thinScarf.getCreatedAt();
+
+        //when
+        Slice<Cloth> clothList = sut.searchCloths(cursor, null, limit, ClothType.SCARF,user.getId());
+        List<Cloth> content = clothList.getContent();
+
+        //then
+        assertThat(clothList.hasNext()).isTrue();
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0)).isEqualTo(redScarf);
+        assertThat(content.get(1)).isEqualTo(whiteScarf);
+    }
+
 }

--- a/src/test/java/com/codeit/weatherwear/domain/clothes/service/AttributeDefServiceTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/clothes/service/AttributeDefServiceTest.java
@@ -12,6 +12,8 @@ import com.codeit.weatherwear.domain.clothes.dto.response.ClothesAttributeDefDto
 import com.codeit.weatherwear.domain.clothes.dto.request.ClothesAttributeDefUpdateRequest;
 
 import com.codeit.weatherwear.domain.clothes.entity.Attribute;
+import com.codeit.weatherwear.domain.clothes.exception.AttributeAlreadyExistsException;
+import com.codeit.weatherwear.domain.clothes.exception.InvalidAttributeNameException;
 import com.codeit.weatherwear.domain.clothes.mapper.AttributeMapper;
 import com.codeit.weatherwear.domain.clothes.repository.AttributeRepository;
 import java.time.Instant;
@@ -79,8 +81,8 @@ public class AttributeDefServiceTest {
             //when
             //then
             assertThatThrownBy(() -> sut.create(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 등록된 속성입니다.");
+                .isInstanceOf(AttributeAlreadyExistsException.class)
+                .hasMessage("속성 등록 실패");
         }
     }
 
@@ -131,8 +133,8 @@ public class AttributeDefServiceTest {
             //when
             //then
             assertThatThrownBy(() -> sut.update(id, request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("해당 속성명이 일치하지 않습니다.");
+                .isInstanceOf(InvalidAttributeNameException.class)
+                .hasMessage("잘못된 속성명입니다.");
             verify(attributeRepository, times(1)).findById(id);
         }
     }

--- a/src/test/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceTest.java
@@ -16,6 +16,8 @@ import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
 import com.codeit.weatherwear.domain.clothes.entity.Attribute;
 import com.codeit.weatherwear.domain.clothes.entity.Cloth;
 import com.codeit.weatherwear.domain.clothes.entity.ClothType;
+import com.codeit.weatherwear.domain.clothes.exception.AttributeNotFoundException;
+import com.codeit.weatherwear.domain.clothes.exception.ClothNotFoundException;
 import com.codeit.weatherwear.domain.clothes.mapper.ClothMapper;
 import com.codeit.weatherwear.domain.clothes.repository.AttributeRepository;
 import com.codeit.weatherwear.domain.clothes.repository.ClothRepository;
@@ -137,8 +139,8 @@ public class ClothServiceTest {
 
             // when & then
             assertThatThrownBy(() -> sut.create(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("존재하지 않는 속성");
+                .isInstanceOf(AttributeNotFoundException.class)
+                .hasMessageContaining("속성 확인 실패");
 
             verify(clothRepository, never()).save(any());
         }
@@ -182,8 +184,8 @@ public class ClothServiceTest {
 
             // when & then
             assertThatThrownBy(() -> sut.delete(id))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("의상을 찾을 수 없습니다");
+                .isInstanceOf(ClothNotFoundException.class)
+                .hasMessageContaining("옷 확인 실패");
             verify(clothRepository, times(1)).findById(id);
             verify(clothRepository, never()).delete(any());
         }


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #90 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> refactor/90/cloth-attribute-error-log -> dev

### 📑 변경 사항
> log작업 추가,
커스텀 예외 적용,
조회 테스트 코드 추가(repository)

### 🛠 테스트 결과
> <img width="429" alt="스크린샷 2025-07-02 오후 8 59 24" src="https://github.com/user-attachments/assets/e1acf64e-901e-48b1-8403-0cc0ec385158" />


### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

### 추가코멘트
1. 엔티티에서 update(String name, List<String> selectableValues) 는 업데이트만 하고 중복 등 검사부분은 서비스로 옮겼습니다.
2. H2 호환성 문제
<img width="556" alt="스크린샷 2025-07-02 오후 5 31 25" src="https://github.com/user-attachments/assets/391b8026-d9fc-44d3-a8ce-8b652b079e48" />

h2에서는 예약어로 value를 사용해서 value그대로 컬럼명을 작성하면 테이블이 만들어지지 않더라구요.
swagger에서는 `value`로 작성되어있어 우선 임시로 `"`를 이용하여 해결하였습니다.