### PR TITLE
Fix: 프로필 수정 API 픽스 #78

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/user/controller/UserController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/controller/UserController.java
@@ -33,56 +33,56 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/users")
 public class UserController {
 
-    private final UserService userService;
+  private final UserService userService;
 
-    @PostMapping("")
-    public ResponseEntity<UserDto> createUser(
-        @Valid @RequestBody UserCreateRequest userCreateRequest) {
-        UserDto result = userService.create(userCreateRequest);
-        return ResponseEntity.ok(result);
-    }
+  @PostMapping("")
+  public ResponseEntity<UserDto> createUser(
+      @Valid @RequestBody UserCreateRequest userCreateRequest) {
+    UserDto result = userService.create(userCreateRequest);
+    return ResponseEntity.ok(result);
+  }
 
-    @GetMapping("/{userId}/profiles")
-    public ResponseEntity<ProfileDto> findProfile(@PathVariable UUID userId) {
-        ProfileDto result = userService.findProfile(userId);
-        return ResponseEntity.ok(result);
-    }
+  @GetMapping("/{userId}/profiles")
+  public ResponseEntity<ProfileDto> findProfile(@PathVariable UUID userId) {
+    ProfileDto result = userService.findProfile(userId);
+    return ResponseEntity.ok(result);
+  }
 
-    @GetMapping("")
-    public ResponseEntity<PageResponse> searchUsers(
-        @ModelAttribute @Valid UserSearchRequest userSearchRequest) {
-        PageResponse result = userService.searchUsers(userSearchRequest);
-        return ResponseEntity.ok(result);
-    }
+  @GetMapping("")
+  public ResponseEntity<PageResponse> searchUsers(
+      @ModelAttribute @Valid UserSearchRequest userSearchRequest) {
+    PageResponse result = userService.searchUsers(userSearchRequest);
+    return ResponseEntity.ok(result);
+  }
 
-    @PatchMapping(value = "/{userId}/profiles", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ProfileDto> updateProfile(
-        @PathVariable UUID userId,
-        @Valid @RequestPart ProfileUpdateRequest profileUpdateRequest,
-        @RequestPart(required = false) MultipartFile profileImage) {
-        // TODO: S3 세팅 후 프로필 이미지 업데이트 추가
-        ProfileDto result = userService.updateProfile(userId, profileUpdateRequest);
-        return ResponseEntity.ok(result);
-    }
+  @PatchMapping(value = "/{userId}/profiles", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<ProfileDto> updateProfile(
+      @PathVariable UUID userId,
+      @Valid @RequestPart("request") ProfileUpdateRequest profileUpdateRequest,
+      @RequestPart(required = false) MultipartFile profileImage) {
+    // TODO: S3 세팅 후 프로필 이미지 업데이트 추가
+    ProfileDto result = userService.updateProfile(userId, profileUpdateRequest);
+    return ResponseEntity.ok(result);
+  }
 
-    @PatchMapping("/{userId}/lock")
-    public ResponseEntity<UUID> updateLock(@PathVariable UUID userId,
-        @RequestBody UserLockUpdateRequest userLockUpdateRequest) {
-        UUID result = userService.updateLock(userId, userLockUpdateRequest);
-        return ResponseEntity.ok(result);
-    }
+  @PatchMapping("/{userId}/lock")
+  public ResponseEntity<UUID> updateLock(@PathVariable UUID userId,
+      @RequestBody UserLockUpdateRequest userLockUpdateRequest) {
+    UUID result = userService.updateLock(userId, userLockUpdateRequest);
+    return ResponseEntity.ok(result);
+  }
 
-    @PatchMapping("/{userId}/password")
-    public ResponseEntity<Void> updatePassword(@PathVariable UUID userId,
-        @Valid @RequestBody ChangePasswordRequest changePasswordRequest) {
-        userService.updatePassword(userId, changePasswordRequest);
-        return ResponseEntity.ok().build();
-    }
+  @PatchMapping("/{userId}/password")
+  public ResponseEntity<Void> updatePassword(@PathVariable UUID userId,
+      @Valid @RequestBody ChangePasswordRequest changePasswordRequest) {
+    userService.updatePassword(userId, changePasswordRequest);
+    return ResponseEntity.ok().build();
+  }
 
-    @PatchMapping("/{userId}/role")
-    public ResponseEntity<UserDto> updateRole(@PathVariable UUID userId,
-        @RequestBody UserRoleUpdateRequest userRoleUpdateRequest) {
-        UserDto result = userService.updateRole(userId, userRoleUpdateRequest);
-        return ResponseEntity.ok(result);
-    }
+  @PatchMapping("/{userId}/role")
+  public ResponseEntity<UserDto> updateRole(@PathVariable UUID userId,
+      @RequestBody UserRoleUpdateRequest userRoleUpdateRequest) {
+    UserDto result = userService.updateRole(userId, userRoleUpdateRequest);
+    return ResponseEntity.ok(result);
+  }
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#78 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- 프로필 수정 API를 픽스했습니다.

코드 스타일
### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.

---

### 추가 코멘트

프론트엔드 화면에서 프로필 업데이트 기능이 동작하지 않는 문제가 있었습니다.
`HttpMediaTypeNotSupportedException`을 만나 500 에러를 만났기 때문인데요.

원인은 간단했습니다.

프론트에서 현재 보내는 데이터는 이처럼 "request" 키와 파일이 있었는데요.
```
Content-Disposition: form-data; name="request"; filename="blob"
Content-Type: application/json
```
제가 ProfileUpdateRequest를 파라미터로 받을 때 키 이름을 따로 지정하지 않아
서버에서는 "profileUpdateRequest"라는 키를 찾고 있었던 겁니다.
```
 @PatchMapping(value = "/{userId}/profiles", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
  public ResponseEntity<ProfileDto> updateProfile(
      @PathVariable UUID userId,
      @Valid @RequestPart ProfileUpdateRequest profileUpdateRequest,
      @RequestPart(required = false) MultipartFile profileImage)
```

그래서 다음과 같이 키 이름을 명시하였습니다. 간단한 방법으로는 그냥 ```ProfileUpdateRequest request```라고 할 수도 있습니다.
```
@Valid @RequestPart("request")
```

RequestPart로 받을 때 프론트에서는 어떤 키로 보내고 있느냐가 중요하다는 걸 알게 됐어요.

추가로, 코드 스타일이 다시 적용되어 파일 전체가 수정됐는데, 위에서 설명한 한 줄만 달라졌습니다..