### PR TITLE
Feat: 구매링크로 옷 등록 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,8 +106,8 @@ dependencies {
     // Java Mail Sender
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
-    //웹 크롤링 Jsoup
-    implementation 'org.jsoup:jsoup:1.16.1'
+    //웹 크롤링 Selenium
+    implementation 'org.seleniumhq.selenium:selenium-java:4.10.0'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,9 @@ dependencies {
 
     // Java Mail Sender
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    //웹 크롤링 Jsoup
+    implementation 'org.jsoup:jsoup:1.16.1'
 }
 
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/controller/ClothController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/controller/ClothController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -59,7 +60,7 @@ public class ClothController implements ClothApi {
      */
     @Override
     @GetMapping("/extractions")
-    public ResponseEntity<ClothesDto> createFromUrl(String url) {
+    public ResponseEntity<ClothesDto> createFromUrl(@RequestParam String url) {
       log.info("[url로 옷 등록 요청] url: {}", url);
 
       ClothesDto urlCloth=clothService.createFromUrl(url);

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/controller/ClothController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/controller/ClothController.java
@@ -16,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,6 +51,22 @@ public class ClothController implements ClothApi {
     return ResponseEntity.status(HttpStatus.CREATED).body(createClothes);
   }
 
+    /**
+     * 의상을 url으로부터 불러와 등록합니다.
+     *
+     * @param url 구매 사이트 url
+     * @return
+     */
+    @Override
+    @GetMapping("/extractions")
+    public ResponseEntity<ClothesDto> createFromUrl(String url) {
+      log.info("[url로 옷 등록 요청] url: {}", url);
+
+      ClothesDto urlCloth=clothService.createFromUrl(url);
+      return ResponseEntity.ok(urlCloth);
+    }
+
+
   /**
    * 의상을 조회합니다.
    *
@@ -57,10 +74,11 @@ public class ClothController implements ClothApi {
    * @return
    */
   @Override
+  @GetMapping
   public ResponseEntity<PageResponse<ClothesDto>> searchClothes(
-      @ModelAttribute @Valid ClothesSearchRequest request) {
-    log.info("[옷 목록 조회 요청] ownerId: {}, typeEqual: {}, limit: {}",
-        request.ownerId(), request.typeEqual(), request.limit());
+    @ModelAttribute @Valid ClothesSearchRequest request) {
+      log.info("[옷 목록 조회 요청] ownerId: {}, typeEqual: {}, limit: {}",
+          request.ownerId(),request.typeEqual(), request.limit());
 
     PageResponse<ClothesDto> result = clothService.searchClothes(request);
     return ResponseEntity.ok(result);
@@ -105,6 +123,5 @@ public class ClothController implements ClothApi {
     clothService.delete(clothesId);
     return ResponseEntity.noContent().build();
   }
-
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/controller/api/ClothApi.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/controller/api/ClothApi.java
@@ -108,5 +108,21 @@ public interface ClothApi {
             required = true
         )
         @PathVariable(value = "clothesId") UUID clothesId);
+
+    @Operation(summary = "구매 링크로 옷 정보 불러오기", description = "구매 링크로 옷 정보 불러오기 API")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "구매 링크로 옷 정보 불러오기 성공",
+            content = @Content(schema = @Schema(implementation = ClothesDto.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "구매 링크로 옷 정보 불러오기 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    @GetMapping("/extractions")
+    ResponseEntity<ClothesDto> createFromUrl(@Parameter(required = true) String url);
+
 }
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepository.java
@@ -17,7 +17,7 @@ public interface ClothRepository extends JpaRepository<Cloth, UUID>, ClothReposi
   Optional<Cloth> findByIdWithAttributes(UUID clothId);
 
   @EntityGraph(attributePaths = {"clothesWithAttributes", "clothesWithAttributes.attribute"})
-  @Query("SELECT c FROM Cloth c WHERE c.id IN :ids")
+  @Query("SELECT c FROM Cloth c WHERE c.id IN :clothIds")
   List<Cloth> findAllByIdWithAttributes(List<UUID> clothIds);
 
   @EntityGraph(attributePaths = {"clothesWithAttributes", "clothesWithAttributes.attribute"})

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothService.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 public interface ClothService {
     ClothesDto create(ClothesCreateRequest request);
+    ClothesDto createFromUrl(String url);
     ClothesDto update(UUID clothesId,ClothesUpdateRequest request);
     PageResponse<ClothesDto> searchClothes(ClothesSearchRequest request);
     void delete(UUID clothesId);

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -85,6 +85,17 @@ public class ClothServiceImpl implements ClothService {
     }
 
     /**
+     * 구매링크로 의상 등록
+     *
+     * @param url 구매 링크
+     * @return 의상 DTO
+     */
+    @Override
+    public ClothesDto createFromUrl(String url) {
+
+    }
+
+    /**
      * 의상 수정
      *
      * @param clothesId 수정 요청 ID

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -111,7 +111,7 @@ public class ClothServiceImpl implements ClothService {
         chromeOptions.setPageLoadStrategy(PageLoadStrategy.NONE);
 
         WebDriver driver = new ChromeDriver(chromeOptions);
-        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(6));
+        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(10));
         try {
             driver.get(url);
             SiteParser parser = siteParsers.stream()

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -16,11 +16,13 @@ import com.codeit.weatherwear.domain.clothes.exception.InvalidAttributeNameExcep
 import com.codeit.weatherwear.domain.clothes.mapper.ClothMapper;
 import com.codeit.weatherwear.domain.clothes.repository.AttributeRepository;
 import com.codeit.weatherwear.domain.clothes.repository.ClothRepository;
+import com.codeit.weatherwear.domain.clothes.service.parser.SiteParser;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
 import com.codeit.weatherwear.global.request.SortDirection;
 import com.codeit.weatherwear.global.response.PageResponse;
+import java.io.IOException;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -31,6 +33,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,6 +49,7 @@ public class ClothServiceImpl implements ClothService {
     private final AttributeRepository attributeRepository;
     private final UserRepository userRepository;
     private final ClothMapper clothMapper;
+    private final List<SiteParser> siteParsers;
 
     /**
      * 의상 등록
@@ -89,10 +94,23 @@ public class ClothServiceImpl implements ClothService {
      *
      * @param url 구매 링크
      * @return 의상 DTO
+     * @throws IOException
      */
     @Override
     public ClothesDto createFromUrl(String url) {
-
+      try {
+        Document doc = Jsoup.connect(url).get();
+          //알맞은 파서 찾기
+          SiteParser parser = siteParsers.stream()
+              .filter(p -> p.supports(url))
+              .findFirst()
+              //TODO: 추후 커스텀 예외 고민하기
+              .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 사이트입니다: " + url));
+          //추출 및 반환
+          return parser.extract(doc);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
 
     /**

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -111,7 +111,7 @@ public class ClothServiceImpl implements ClothService {
         chromeOptions.setPageLoadStrategy(PageLoadStrategy.NONE);
 
         WebDriver driver = new ChromeDriver(chromeOptions);
-        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(10));
+        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(6));
         try {
             driver.get(url);
             SiteParser parser = siteParsers.stream()

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -108,10 +108,10 @@ public class ClothServiceImpl implements ClothService {
         chromeOptions.addArguments("--no-sandbox");
         chromeOptions.addArguments("--disable-gpu");
         chromeOptions.addArguments("--user-agent=Mozilla/5.0 (Linux; Android 10) Chrome/90.0.4430.85 Mobile Safari/537.36");
-        chromeOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
+        chromeOptions.setPageLoadStrategy(PageLoadStrategy.NONE);
 
         WebDriver driver = new ChromeDriver(chromeOptions);
-        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(30));
+        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(6));
         try {
             driver.get(url);
             SiteParser parser = siteParsers.stream()

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -23,6 +23,7 @@ import com.codeit.weatherwear.domain.user.repository.UserRepository;
 import com.codeit.weatherwear.global.request.SortDirection;
 import com.codeit.weatherwear.global.response.PageResponse;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -33,8 +34,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
+import org.openqa.selenium.PageLoadStrategy;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -98,19 +101,31 @@ public class ClothServiceImpl implements ClothService {
      */
     @Override
     public ClothesDto createFromUrl(String url) {
-      try {
-        Document doc = Jsoup.connect(url).get();
-          //알맞은 파서 찾기
-          SiteParser parser = siteParsers.stream()
-              .filter(p -> p.supports(url))
-              .findFirst()
-              //TODO: 추후 커스텀 예외 고민하기
-              .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 사이트입니다: " + url));
-          //추출 및 반환
-          return parser.extract(doc);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
+
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.addArguments("--headless=new");
+        chromeOptions.addArguments("--lang=ko");
+        chromeOptions.addArguments("--no-sandbox");
+        chromeOptions.addArguments("--disable-gpu");
+        chromeOptions.addArguments("--user-agent=Mozilla/5.0 (Linux; Android 10) Chrome/90.0.4430.85 Mobile Safari/537.36");
+        chromeOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
+
+        WebDriver driver = new ChromeDriver(chromeOptions);
+        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(30));
+        try {
+            driver.get(url);
+            SiteParser parser = siteParsers.stream()
+                .filter(p -> p.supports(url))
+                .findFirst()
+                //TODO: 추후 커스텀 예외 고민
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 사이트입니다: " + url));
+            parser.waitUntilReady(driver);
+            return parser.extract(driver);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            driver.quit();
+        }
     }
 
     /**

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
@@ -1,9 +1,13 @@
 package com.codeit.weatherwear.domain.clothes.service.parser;
 
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
-import java.util.Optional;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,19 +15,38 @@ public class MusinsaParser implements SiteParser {
 
   @Override
   public boolean supports(String url) {
-    return url.contains("musinsa.com");
+    return url.contains("musinsa");
   }
 
   @Override
-  public ClothesDto extract(Document document) {
-    //상품명, 대표이미지 추출 ( 없으면 빈값 )
-    String productName = Optional.ofNullable(
-        document.selectFirst("span[data-mds='Typography'].text-title_18px_med")
-    ).map(Element::text).orElse("");
+  public void waitUntilReady(WebDriver driver) {
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    wait.until(ExpectedConditions.presenceOfElementLocated(
+        By.cssSelector("span.text-title_18px_med")
+    ));
+    wait.until(ExpectedConditions.presenceOfElementLocated(
+        By.cssSelector("div[data-content-name='대표이미지']")
+    ));
+  }
 
-    String imageUrl = Optional.ofNullable(
-        document.selectFirst("img[src*='image.msscdn.net']")
-    ).map(el -> el.attr("src")).orElse("");
+  @Override
+  public ClothesDto extract(WebDriver driver) {
+    //상품명, 대표이미지 추출 ( 없으면 빈값 )
+    String productName = "";
+    String imageUrl = "";
+
+    try {
+      WebElement nameElement = driver.findElement(
+          By.cssSelector("span.text-title_18px_med")
+      );
+      productName = nameElement.getText();
+    } catch (NoSuchElementException ignored) {}
+
+    try {
+      WebElement mainImageContainer = driver.findElement(By.cssSelector("div[data-content-name='대표이미지']"));
+      WebElement imageElement = mainImageContainer.findElement(By.tagName("img"));
+      imageUrl = imageElement.getAttribute("src");
+    } catch (NoSuchElementException ignored) {}
 
     return ClothesDto.builder()
         .name(productName)

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
@@ -3,6 +3,7 @@ package com.codeit.weatherwear.domain.clothes.service.parser;
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
 import java.time.Duration;
 import java.util.NoSuchElementException;
+import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -11,6 +12,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class MusinsaParser implements SiteParser {
 
   @Override
@@ -20,10 +22,8 @@ public class MusinsaParser implements SiteParser {
 
   @Override
   public void waitUntilReady(WebDriver driver) {
+    log.info("[무신사 옷 정보 추출 시작]");
     WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
-    wait.until(ExpectedConditions.presenceOfElementLocated(
-        By.cssSelector("span.text-title_18px_med")
-    ));
     wait.until(ExpectedConditions.presenceOfElementLocated(
         By.cssSelector("div[data-content-name='대표이미지']")
     ));
@@ -36,17 +36,13 @@ public class MusinsaParser implements SiteParser {
     String imageUrl = "";
 
     try {
-      WebElement nameElement = driver.findElement(
-          By.cssSelector("span.text-title_18px_med")
-      );
-      productName = nameElement.getText();
-    } catch (NoSuchElementException ignored) {}
-
-    try {
       WebElement mainImageContainer = driver.findElement(By.cssSelector("div[data-content-name='대표이미지']"));
       WebElement imageElement = mainImageContainer.findElement(By.tagName("img"));
       imageUrl = imageElement.getAttribute("src");
+      productName = imageElement.getAttribute("alt");
     } catch (NoSuchElementException ignored) {}
+
+    log.info("[옷 정보 추출 완료 : {}, 상품명: {}","무신사", productName);
 
     return ClothesDto.builder()
         .name(productName)

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
@@ -1,0 +1,33 @@
+package com.codeit.weatherwear.domain.clothes.service.parser;
+
+import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
+import java.util.Optional;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MusinsaParser implements SiteParser {
+
+  @Override
+  public boolean supports(String url) {
+    return url.contains("musinsa.com");
+  }
+
+  @Override
+  public ClothesDto extract(Document document) {
+    //상품명, 대표이미지 추출 ( 없으면 빈값 )
+    String productName = Optional.ofNullable(
+        document.selectFirst("span[data-mds='Typography'].text-title_18px_med")
+    ).map(Element::text).orElse("");
+
+    String imageUrl = Optional.ofNullable(
+        document.selectFirst("img[src*='image.msscdn.net']")
+    ).map(el -> el.attr("src")).orElse("");
+
+    return ClothesDto.builder()
+        .name(productName)
+        .imageUrl(imageUrl)
+        .build();
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
@@ -23,9 +23,9 @@ public class MusinsaParser implements SiteParser {
   @Override
   public void waitUntilReady(WebDriver driver) {
     log.info("[무신사 옷 정보 추출 시작]");
-    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(20));
     wait.until(ExpectedConditions.presenceOfElementLocated(
-        By.cssSelector("div[data-content-name='대표이미지']")
+        By.cssSelector("div[data-content-name='대표이미지'] img[alt][src]")
     ));
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/SiteParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/SiteParser.java
@@ -1,0 +1,10 @@
+package com.codeit.weatherwear.domain.clothes.service.parser;
+
+import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+
+public interface SiteParser {
+  boolean supports(String url);
+  ClothesDto extract(Document document);
+}

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/SiteParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/SiteParser.java
@@ -1,10 +1,10 @@
 package com.codeit.weatherwear.domain.clothes.service.parser;
 
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
-import org.jsoup.nodes.Document;
-import org.springframework.stereotype.Component;
+import org.openqa.selenium.WebDriver;
 
 public interface SiteParser {
   boolean supports(String url);
-  ClothesDto extract(Document document);
+  void waitUntilReady(WebDriver driver);
+  ClothesDto extract(WebDriver driver);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
@@ -1,0 +1,36 @@
+package com.codeit.weatherwear.domain.clothes.service.parser;
+
+import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
+import java.util.Optional;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TwentyNineCmParser implements SiteParser{
+
+  @Override
+  public boolean supports(String url) {
+    return url.contains("29cm.com");
+  }
+
+  @Override
+  public ClothesDto extract(Document document) {
+    //상품명, 대표이미지 추출 ( 없으면 빈값 )
+    String productName = Optional.ofNullable(
+        document.getElementById("pdp_product_name")
+    ).map(Element::text).orElse("");
+
+    String imageUrl = Optional.ofNullable(
+        document.selectFirst("img[src*='img.29cm.co.kr/item']")
+    ).map(img -> img.attr("src")).orElse("");
+
+
+
+    return ClothesDto.builder()
+        .name(productName)
+        .imageUrl(imageUrl)
+        .build();
+  }
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
@@ -1,9 +1,13 @@
 package com.codeit.weatherwear.domain.clothes.service.parser;
 
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
-import java.util.Optional;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,21 +15,31 @@ public class TwentyNineCmParser implements SiteParser{
 
   @Override
   public boolean supports(String url) {
-    return url.contains("29cm.com");
+    return url.contains("29cm");
   }
 
   @Override
-  public ClothesDto extract(Document document) {
+  public void waitUntilReady(WebDriver driver) {
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    wait.until(ExpectedConditions.presenceOfElementLocated(
+        By.id("pdp_product_name")
+    ));
+  }
+
+  @Override
+  public ClothesDto extract(WebDriver driver) {
     //상품명, 대표이미지 추출 ( 없으면 빈값 )
-    String productName = Optional.ofNullable(
-        document.getElementById("pdp_product_name")
-    ).map(Element::text).orElse("");
+    String productName = "";
+    String imageUrl = "";
+    try {
+      WebElement nameElement = driver.findElement(By.id("pdp_product_name"));
+      productName = nameElement.getText();
+    } catch (NoSuchElementException ignored) {}
 
-    String imageUrl = Optional.ofNullable(
-        document.selectFirst("img[src*='img.29cm.co.kr/item']")
-    ).map(img -> img.attr("src")).orElse("");
-
-
+    try {
+      WebElement imageElement = driver.findElement(By.cssSelector("img[src*='img.29cm.co.kr/item']"));
+      imageUrl = imageElement.getAttribute("src");
+    } catch (NoSuchElementException ignored) {}
 
     return ClothesDto.builder()
         .name(productName)

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
@@ -23,7 +23,7 @@ public class TwentyNineCmParser implements SiteParser{
   @Override
   public void waitUntilReady(WebDriver driver) {
     log.info("[29cm 옷 정보 추출 시작]");
-    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(20));
     wait.until(ExpectedConditions.presenceOfElementLocated(
         By.id("pdp_product_name")
     ));

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
@@ -3,6 +3,7 @@ package com.codeit.weatherwear.domain.clothes.service.parser;
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
 import java.time.Duration;
 import java.util.NoSuchElementException;
+import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -11,6 +12,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class TwentyNineCmParser implements SiteParser{
 
   @Override
@@ -20,9 +22,13 @@ public class TwentyNineCmParser implements SiteParser{
 
   @Override
   public void waitUntilReady(WebDriver driver) {
+    log.info("[29cm 옷 정보 추출 시작]");
     WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
     wait.until(ExpectedConditions.presenceOfElementLocated(
         By.id("pdp_product_name")
+    ));
+    wait.until(ExpectedConditions.presenceOfElementLocated(
+        By.cssSelector("img[src*='img.29cm.co.kr/item']")
     ));
   }
 
@@ -41,6 +47,7 @@ public class TwentyNineCmParser implements SiteParser{
       imageUrl = imageElement.getAttribute("src");
     } catch (NoSuchElementException ignored) {}
 
+    log.info("[옷 정보 추출 완료 : {}, 상품명: {}","29cm", productName);
     return ClothesDto.builder()
         .name(productName)
         .imageUrl(imageUrl)

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
@@ -1,9 +1,13 @@
 package com.codeit.weatherwear.domain.clothes.service.parser;
 
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
-import java.util.Optional;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,20 +15,31 @@ public class ZigZagParser implements SiteParser{
 
   @Override
   public boolean supports(String url) {
-    return url.contains("zigzag.com");
+    return url.contains("zigzag");
   }
 
   @Override
-  public ClothesDto extract(Document document) {
+  public void waitUntilReady(WebDriver driver) {
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    wait.until(ExpectedConditions.presenceOfElementLocated(
+        By.cssSelector("h1[class*='BODY_15']")
+    ));
+  }
+
+  @Override
+  public ClothesDto extract(WebDriver driver) {
     //상품명, 대표이미지 추출 ( 없으면 빈값 )
-    String productName = Optional.ofNullable(
-        document.selectFirst("h1[class*='BODY_15']")
-    ).map(Element::text).orElse("");
+    String productName = "";
+    String imageUrl = "";
+    try {
+      WebElement nameElement = driver.findElement(By.cssSelector("h1[class*='BODY_15']"));
+      productName = nameElement.getText();
+    } catch (NoSuchElementException ignored) {}
 
-    String imageUrl = Optional.ofNullable(
-        document.selectFirst("img[src*='cf.product-image.s.zigzag.kr']")
-    ).map(el -> el.attr("src")).orElse("");
-
+    try {
+      WebElement imageElement = driver.findElement(By.cssSelector("img[src*='cf.product-image.s.zigzag.kr']"));
+      imageUrl = imageElement.getAttribute("src");
+    } catch (NoSuchElementException ignored) {}
 
     return ClothesDto.builder()
         .name(productName)

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
@@ -1,0 +1,34 @@
+package com.codeit.weatherwear.domain.clothes.service.parser;
+
+import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
+import java.util.Optional;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ZigZagParser implements SiteParser{
+
+  @Override
+  public boolean supports(String url) {
+    return url.contains("zigzag.com");
+  }
+
+  @Override
+  public ClothesDto extract(Document document) {
+    //상품명, 대표이미지 추출 ( 없으면 빈값 )
+    String productName = Optional.ofNullable(
+        document.selectFirst("h1[class*='BODY_15']")
+    ).map(Element::text).orElse("");
+
+    String imageUrl = Optional.ofNullable(
+        document.selectFirst("img[src*='cf.product-image.s.zigzag.kr']")
+    ).map(el -> el.attr("src")).orElse("");
+
+
+    return ClothesDto.builder()
+        .name(productName)
+        .imageUrl(imageUrl)
+        .build();
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
@@ -3,6 +3,7 @@ package com.codeit.weatherwear.domain.clothes.service.parser;
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
 import java.time.Duration;
 import java.util.NoSuchElementException;
+import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -11,6 +12,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class ZigZagParser implements SiteParser{
 
   @Override
@@ -20,9 +22,13 @@ public class ZigZagParser implements SiteParser{
 
   @Override
   public void waitUntilReady(WebDriver driver) {
+    log.info("[지그재그 옷 정보 추출 시작]");
     WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
     wait.until(ExpectedConditions.presenceOfElementLocated(
         By.cssSelector("h1[class*='BODY_15']")
+    ));
+    wait.until(ExpectedConditions.presenceOfElementLocated(
+        By.cssSelector("img[src*='cf.product-image.s.zigzag.kr']")
     ));
   }
 
@@ -41,6 +47,7 @@ public class ZigZagParser implements SiteParser{
       imageUrl = imageElement.getAttribute("src");
     } catch (NoSuchElementException ignored) {}
 
+    log.info("[옷 정보 추출 완료 : {}, 상품명: {}","지그재그", productName);
     return ClothesDto.builder()
         .name(productName)
         .imageUrl(imageUrl)

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
@@ -23,7 +23,7 @@ public class ZigZagParser implements SiteParser{
   @Override
   public void waitUntilReady(WebDriver driver) {
     log.info("[지그재그 옷 정보 추출 시작]");
-    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(20));
     wait.until(ExpectedConditions.presenceOfElementLocated(
         By.cssSelector("h1[class*='BODY_15']")
     ));

--- a/src/test/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceTest.java
@@ -21,6 +21,7 @@ import com.codeit.weatherwear.domain.clothes.exception.ClothNotFoundException;
 import com.codeit.weatherwear.domain.clothes.mapper.ClothMapper;
 import com.codeit.weatherwear.domain.clothes.repository.AttributeRepository;
 import com.codeit.weatherwear.domain.clothes.repository.ClothRepository;
+import com.codeit.weatherwear.domain.clothes.service.parser.SiteParser;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
 import java.time.Instant;
@@ -46,6 +47,8 @@ public class ClothServiceTest {
     private ClothRepository clothRepository;
     @Mock
     private ClothMapper mapper;
+    @Mock
+    private List<SiteParser> siteParsers;
 
     @InjectMocks
     private ClothServiceImpl sut;


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #99 
### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> feat/99/cloth-addlink -> dev

### 📑 변경 사항
> clothRepository 오타 수정

### 🛠 테스트 결과
> <img width="324" alt="스크린샷 2025-07-07 오후 5 26 35" src="https://github.com/user-attachments/assets/aca5e43f-76e9-4629-a4b5-40376fb19ffe" />

### ✅ PR 올리기 전 체크리스트
- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

### 추가 코멘트
GPT API로 원하는 사이트의 정보를 사용할 수 있도록 하려했으나 사용료가 발생해서 무신사, 지그재그, 29cm 3개를 제외한 나머지 사이트는` 지원하지 않는 사이트 오류`를 낼 예정입니다. 
![2025-07-075 34 07-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/2e5162b7-6a60-483b-908b-dac24bfdbb1e)

1. 지그재그 옷 추출 시간 : 10s
<img width="1122" alt="스크린샷 2025-07-07 오후 4 53 42" src="https://github.com/user-attachments/assets/6dab9601-5131-4597-8051-377c56fbb124" />

2. 29cm 옷 추출 시간: 8s
<img width="1191" alt="스크린샷 2025-07-07 오후 4 55 53" src="https://github.com/user-attachments/assets/7aa94fb8-642f-4bac-a78f-299f6ef35174" />

3. 무신사 옷 추출 시간: 12s
<img width="1201" alt="스크린샷 2025-07-07 오후 5 11 02" src="https://github.com/user-attachments/assets/cb368757-531b-4954-bb9c-1740624a5937" />


주석 수정, 정보 로드 시간 단축, 이미지 처리는 추후 리팩토링 단계에 진행하겠습니다.
대부분 상품명을 잘 갖고오는 것을 확인했으나 일부 상품명은 잘 못갖고오더라구요. 추후 리팩토링 단계 때 확인해보겠습니다.

(테스트 할 때, 완전히 로드된 사이트를 요청해야 성공합니다)