### PR TITLE
Feat: 카카오 OAuth 로그인

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/security/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/config/SecurityConfig.java
@@ -36,7 +36,6 @@ import org.springframework.security.web.authentication.session.NullAuthenticated
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -51,7 +50,7 @@ public class SecurityConfig {
       JwtLogoutHandler jwtLogoutHandler,
       CustomOAuth2UserService customOAuth2UserService,
       @Qualifier("customOAuth2SuccessHandler") AuthenticationSuccessHandler customOAuth2SuccessHandler,
-      CorsConfigurationSource corsConfigurationSource)
+      AuthenticationFailureHandler customAuthenticationFailureHandler)
       throws Exception {
 
     httpSecurity
@@ -67,6 +66,7 @@ public class SecurityConfig {
             .userInfoEndpoint(userInfo -> userInfo
                 .userService(customOAuth2UserService))
             .successHandler(customOAuth2SuccessHandler)
+            .failureHandler(customAuthenticationFailureHandler)
         )
         .sessionManagement(session -> session
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/com/codeit/weatherwear/domain/security/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/config/SecurityConfig.java
@@ -82,9 +82,11 @@ public class SecurityConfig {
         )
         .logout(logout -> logout
             .logoutRequestMatcher(SecurityRequestMatcher.SIGN_OUT)
-            .logoutSuccessUrl("/") // 홈으로
             .deleteCookies("refresh_token")    // 쿠키 삭제
             .addLogoutHandler(jwtLogoutHandler) // JwtSession 삭제 & 토큰 블랙리스트 추가 핸들러
+            .logoutSuccessHandler((request, response, authentication) -> {
+              response.setStatus(HttpStatus.NO_CONTENT.value());
+            })
         )
         .exceptionHandling(exceptionHandler -> exceptionHandler
             .defaultAuthenticationEntryPointFor(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/CustomAuthenticationSuccessHandler.java
@@ -13,8 +13,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
 @RequiredArgsConstructor
@@ -28,11 +26,6 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
       Authentication authentication) throws IOException, ServletException {
-
-    // 인증 정보 저장
-    SecurityContext context = SecurityContextHolder.createEmptyContext();
-    context.setAuthentication(authentication);
-    SecurityContextHolder.setContext(context);
 
     // 인증된 사용자 정보
     CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/CustomUserDetails.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/CustomUserDetails.java
@@ -15,12 +15,12 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 @Slf4j
 public class CustomUserDetails implements UserDetails, OAuth2User {
 
-  private UUID userID;
-  private String email;
-  private String password;
-  private Role role;
-  private boolean locked;
-  private Instant tempPasswordExpirationTime;
+  private final UUID userID;
+  private final String email;
+  private final String password;
+  private final Role role;
+  private final boolean locked;
+  private final Instant tempPasswordExpirationTime;
 
   private Map<String, Object> attributes;
 
@@ -32,10 +32,6 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
     this.role = role;
     this.locked = locked;
     this.tempPasswordExpirationTime = tempPasswordExpirationTime;
-  }
-
-  public CustomUserDetails(Map<String, Object> attributes) {
-    this.attributes = attributes;
   }
 
   @Override

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2SuccessHandler.java
@@ -12,8 +12,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,14 +25,10 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
   @Transactional
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
       Authentication authentication) throws ServletException, IOException {
-    // 인증 정보 저장
-    SecurityContext context = SecurityContextHolder.createEmptyContext();
-    context.setAuthentication(authentication);
-    SecurityContextHolder.setContext(context);
+
     CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
     UUID userId = userDetails.getUserId();
 
-    log.info("oauth: 인증에 성공해 토큰을 발급합니다.");
     // 기존 토큰 무효화 & 새 토큰 발급
     jwtSessionService.invalidateToken(userId);
     JwtSession jwtSession = jwtSessionService.createJwtSession(userId);

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2UserService.java
@@ -6,6 +6,7 @@ import com.codeit.weatherwear.domain.user.entity.Role;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -25,18 +26,33 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
     OAuth2User oAuth2User = super.loadUser(userRequest);
     String provider = userRequest.getClientRegistration().getRegistrationId();  // google / kakao
-    String email = oAuth2User.getAttribute("email");
+
+    String email = null;
+    String name = null;
+
+    if (provider.equals("google")) {
+      email = oAuth2User.getAttribute("email");
+      name = oAuth2User.getAttribute("name");
+    } else if (provider.equals("kakao")) {
+      Map<String, Object> kakaoAccount = oAuth2User.getAttribute("kakao_account");
+      Map<String, Object> profile =
+          kakaoAccount != null ? (Map<String, Object>) kakaoAccount.get("profile") : null;
+      name = profile != null ? (String) profile.get("nickname") : "kakao_user";
+      // 카카오의 경우 이메일을 닉네임+kakao.com으로
+      email = name + "@kakao.com";
+    } else {
+      throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다: " + provider);
+    }
 
     User user = userRepository.findByEmail(email)
         .orElse(null);
     if (user == null) {
       // 새로운 회원으로 추가
-      log.info("oauth2: DB에 회원 정보가 없어 새로운 회원으로 추가합니다.");
       user = userRepository.save(User.builder()
-          .name(oAuth2User.getAttribute("name"))
+          .name(name)
           .email(email)
           .password("")
-          .linkedOAuthProviders(List.of(OAuthProvider.google))
+          .linkedOAuthProviders(List.of(OAuthProvider.valueOf(provider)))
           .role(Role.USER)
           .build());
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,21 @@ spring:
             scope:
               - email
               - profile
+          kakao:
+            client-id: ${KAKAO_CLIENT_REST_API_KEY}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope:
+              - profile_nickname
+            client-name: Kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
 
 server:
   shutdown: graceful


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#107 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

feat/107/oauth -> kakao

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

카카오 소셜 로그인 기능을 추가했습니다.


### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

---

### 추가 코멘트

구글과 달리 카카오는 사업자 인증을 하지 않으면 이메일을 가져올 수 없어
요구사항에 적힌 내용과 같이 닉네임+kakao.com으로 이메일을 정의했습니다.
![image](https://github.com/user-attachments/assets/a364ba31-aa53-4340-a34b-5ea03c373e22)
그래서 "이소영@kakao.com"과 같이 다소 어색하게 이메일이 저장됩니다...

카카오 관련 API 키가 [공유자료/환경변수](https://www.notion.so/env-env-dev-env-prod-env-test-21b97c15da0880d8bdefe80a6316f1d4) 페이지에 업데이트 됐습니다.
