### PR TITLE
Refactor: Weather/Location 관련 기능 리팩토링 및 주석 추가

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/location/api/LocationApiClient.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/api/LocationApiClient.java
@@ -1,5 +1,7 @@
 package com.codeit.weatherwear.domain.location.api;
 
+import com.codeit.weatherwear.domain.location.exception.KakaoGeoApiRequestException;
+import com.codeit.weatherwear.domain.location.exception.KakaoGeoApiResponseException;
 import com.codeit.weatherwear.domain.location.parser.LocationApiParser;
 import com.codeit.weatherwear.global.properties.LocationApiProperties;
 import java.io.IOException;
@@ -14,22 +16,29 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+/**
+ * 외부 API (카카오 지도 API - 주소 정보) 요청
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class LocationApiClient {
 
+  // 입력 좌표값
   private static final String INPUT_COORD = "WGS84";
 
   private final LocationApiProperties apiProperties;
   private final LocationApiParser locationApiParser;
 
   public List<String> getRegionNames(double latitude, double longitude) {
+    // api 요청 URL 등록
     String requestUrl = String.format(
         "%s?x=%f&y=%f&input_coord=%s", apiProperties.getApiUrl(), longitude, latitude, INPUT_COORD
     );
 
+    // HTTP 클라이언트 생성
     HttpClient client = HttpClient.newHttpClient();
+    // HTTP 요청 생성
     HttpRequest request = HttpRequest.newBuilder()
         .uri(URI.create(requestUrl))
         .header("Authorization", "KakaoAK " + apiProperties.getApiKey())
@@ -37,18 +46,17 @@ public class LocationApiClient {
         .build();
 
     try {
+      // 응답 값 받아오기 - 응답값 body bytes를 String으로 변환
       HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
       if (response.statusCode() != HttpStatus.OK.value()) {
-        // todo: 예외 처리 필요
-        throw new IllegalStateException("카카오 API 응답 오류: statusCode=" + response.statusCode());
+        throw new KakaoGeoApiResponseException(response.statusCode());
       }
 
+      // 응답 body의 주소 정보를 파싱하여 ["서울시", "종로구", "창경궁로"]와 같이 반환
       return locationApiParser.parse(response.body());
     } catch (IOException | InterruptedException e) {
-      // todo: 예외 처리 필요
-      log.error("cause: {}\nmessage: {}", e.getCause(), e.getMessage());
-      throw new RuntimeException();
-
+      log.error("주소 정보 요청 중 오류 - cause: {}\nmessage: {}", e.getCause(), e.getMessage());
+      throw new KakaoGeoApiRequestException();
     }
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/location/exception/AddressJsonParseException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/exception/AddressJsonParseException.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.domain.location.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+
+public class AddressJsonParseException extends CustomException {
+
+  public AddressJsonParseException() {
+    super(ErrorCode.ADDRESS_JSON_PARSE_ERROR);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/location/exception/KakaoGeoApiRequestException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/exception/KakaoGeoApiRequestException.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.domain.location.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+
+public class KakaoGeoApiRequestException extends CustomException {
+
+  public KakaoGeoApiRequestException() {
+    super(ErrorCode.KAKAO_GEO_API_REQUEST_ERROR);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/location/exception/KakaoGeoApiResponseException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/exception/KakaoGeoApiResponseException.java
@@ -1,0 +1,12 @@
+package com.codeit.weatherwear.domain.location.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+import java.util.Map;
+
+public class KakaoGeoApiResponseException extends CustomException {
+
+  public KakaoGeoApiResponseException(int status) {
+    super(ErrorCode.KAKAO_GEO_API_RESPONSE_ERROR, Map.of("status", status));
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/location/exception/LocationNotFoundException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/exception/LocationNotFoundException.java
@@ -1,0 +1,13 @@
+package com.codeit.weatherwear.domain.location.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+import java.util.Map;
+
+public class LocationNotFoundException extends CustomException {
+
+  public LocationNotFoundException(double latitude, double longitude) {
+    super(ErrorCode.LOCATION_NOT_FOUND_BY_GEO_POINT,
+        Map.of("latitude", latitude, "longitude", longitude));
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/location/exception/MissingAddressFieldException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/exception/MissingAddressFieldException.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.domain.location.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+
+public class MissingAddressFieldException extends CustomException {
+
+  public MissingAddressFieldException() {
+    super(ErrorCode.ADDRESS_FIELD_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/location/parser/LocationApiParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/parser/LocationApiParser.java
@@ -1,5 +1,7 @@
 package com.codeit.weatherwear.domain.location.parser;
 
+import com.codeit.weatherwear.domain.location.exception.AddressJsonParseException;
+import com.codeit.weatherwear.domain.location.exception.MissingAddressFieldException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,23 +21,23 @@ public class LocationApiParser {
   public List<String> parse(String responseBody) {
     try {
       ObjectMapper mapper = new ObjectMapper();
+      // 응답 JSON에서 documents[0].address 노드를 추출
       JsonNode root = mapper.readTree(responseBody);
       JsonNode address = root.path("documents").get(0).path("address");
 
       if (address.isMissingNode()) {
-        // todo: exception
-        throw new RuntimeException("주소 정보가 없습니다");
+        log.warn("Address Node Not Found");
+        throw new MissingAddressFieldException();
       }
 
+      // List 화 하고자 하는 데이터들만 가져와서 리스트에 넣어 반환
       return ADDRESS_DEPTH_NAME_LIST.stream()
           .map(key -> address.path(key).asText(""))
           .collect(Collectors.toList());
     } catch (JsonProcessingException jpe) {
-      // todo: 예외 처리
-      log.error("JSON 파싱 실패: {}", jpe.getMessage());
-      throw new RuntimeException();
+      log.error("Failed JSON parse: {}", jpe.getMessage());
+      throw new AddressJsonParseException();
     }
   }
-
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/location/service/LocationService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/service/LocationService.java
@@ -9,7 +9,5 @@ public interface LocationService {
 
   Location getLocation(double latitude, double longitude);
 
-  Location findOrCreateByXY(int x, int y);
-
   Location findOrCreateByGeoPoint(double latitude, double longitude);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/location/service/LocationServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/service/LocationServiceImpl.java
@@ -3,10 +3,9 @@ package com.codeit.weatherwear.domain.location.service;
 import com.codeit.weatherwear.domain.location.api.LocationApiClient;
 import com.codeit.weatherwear.domain.location.dto.LocationDto;
 import com.codeit.weatherwear.domain.location.entity.Location;
-import com.codeit.weatherwear.domain.location.mapper.LocationMapper;
+import com.codeit.weatherwear.domain.location.exception.LocationNotFoundException;
 import com.codeit.weatherwear.domain.location.repository.LocationRepository;
 import com.codeit.weatherwear.domain.location.util.LamcUtils;
-import com.codeit.weatherwear.domain.location.util.LamcUtils.GeoPoint;
 import com.codeit.weatherwear.domain.location.util.LamcUtils.GridPoint;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,16 +20,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class LocationServiceImpl implements LocationService {
 
   private final LocationRepository locationRepository;
-  private final LocationMapper locationMapper;
   private final LamcUtils lamcUtils;
   private final LocationApiClient locationApiClient;
 
   @Transactional
   @Override
   public Location findOrCreateLocation(LocationDto locationDto) {
+    log.debug("Request Find or Create Location");
+
     String locationName = locationDto.locationNames().stream()
         .filter(s -> s != null && !s.isBlank())
         .collect(Collectors.joining(" "));
+
     Location location = new Location(
         locationDto.latitude(),
         locationDto.longitude(),
@@ -40,32 +41,22 @@ public class LocationServiceImpl implements LocationService {
     );
 
     // 이미 존재하면 기존 객체 반환
-    return locationRepository.findByLatitudeAndLongitudeAndXAndYAndName(
+    Location resultLocation = locationRepository.findByLatitudeAndLongitudeAndXAndYAndName(
         location.getLatitude(),
         location.getLongitude(),
         location.getX(),
         location.getY(),
         location.getName()
     ).orElseGet(() -> locationRepository.save(location));
-  }
 
-  @Transactional
-  @Override
-  public Location findOrCreateByXY(int x, int y) {
-    GeoPoint geoPoint = lamcUtils.convertToGeo(x, y);
-    List<String> regionNames = locationApiClient.getRegionNames(geoPoint.latitude(),
-        geoPoint.longitude());
-    LocationDto locationDto = new LocationDto(geoPoint.latitude(), geoPoint.longitude(), x, y,
-        regionNames);
-
-    // 생성 OR 조회
-    Location location = findOrCreateLocation(locationDto);
-    return location;
+    log.info("Find Or Create Location Success");
+    return resultLocation;
   }
 
   @Transactional
   @Override
   public Location findOrCreateByGeoPoint(double latitude, double longitude) {
+    log.debug("Request Find or Create Location Using GeoPoint");
     GridPoint gridPoint = lamcUtils.convertToGrid(latitude, longitude);
     List<String> regionNames = locationApiClient.getRegionNames(latitude, longitude);
 
@@ -74,15 +65,17 @@ public class LocationServiceImpl implements LocationService {
 
     // 생성 OR 조회
     Location location = findOrCreateLocation(locationDto);
+    log.info("Find Or Create Location Success Using GeoPoint(latitude, longitude)");
     return location;
   }
 
   @Transactional(readOnly = true)
   @Override
   public Location getLocation(double latitude, double longitude) {
-    // todo: exception
+    log.debug("Request Find Location by GeoPoint(lat, long)");
     Location location = locationRepository.findByLatitudeAndLongitude(latitude, longitude)
-        .orElseThrow(RuntimeException::new);
+        .orElseThrow(() -> new LocationNotFoundException(latitude, longitude));
+    log.info("Find Location Success");
     return location;
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/location/util/LamcUtils.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/util/LamcUtils.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class LamcUtils {
 
+  // Default 값 -> API 문서에 있는 내용 참고
   private static final double DEFAULT_GRID = 5.0;
   private static final double DEG_TO_RAD = Math.PI / 180.0;
   private static final double RAD_TO_DEG = 180.0 / Math.PI;
@@ -21,10 +22,12 @@ public class LamcUtils {
       .yo(675.0 / DEFAULT_GRID)
       .build();
 
+  // 격자값
   public record GridPoint(int nx, int ny) {
 
   }
 
+  // 위경도
   public record GeoPoint(double longitude, double latitude) {
 
   }
@@ -46,7 +49,7 @@ public class LamcUtils {
   }
 
   /**
-   * Lambert Conformal Conic projection
+   * Lambert Conformal Conic projection<br>기상청 API 문서에 나와 있는 변환 로직 JAVA에 맞게 수정하여 사용
    *
    * @param arg1 경도 or X
    * @param arg2 위도 or Y

--- a/src/main/java/com/codeit/weatherwear/domain/security/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/config/SecurityConfig.java
@@ -57,7 +57,6 @@ public class SecurityConfig {
     httpSecurity
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(SecurityRequestMatcher.PUBLIC_MATCHERS).permitAll()
-            .requestMatchers("/api/weathers/**").permitAll()  // todo: 테스트를 위함
             .requestMatchers("/api/**").hasRole("USER")
             .anyRequest().authenticated()
         )

--- a/src/main/java/com/codeit/weatherwear/domain/weather/api/WeatherApiClient.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/api/WeatherApiClient.java
@@ -1,5 +1,7 @@
 package com.codeit.weatherwear.domain.weather.api;
 
+import com.codeit.weatherwear.domain.weather.exception.WeatherApiRequestException;
+import com.codeit.weatherwear.domain.weather.exception.WeatherApiResponseException;
 import com.codeit.weatherwear.global.properties.WeatherApiProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,26 +15,40 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+/**
+ * 기상청 단기 예보 API와 통신하여 데이터를 요청하는 역할
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class WeatherApiClient {
 
-  // todo: 작동만 되도록 아직 추상화나 패키지를 나눠두지 않았음!
-
   private final WeatherApiProperties apiProperties;
 
+  /**
+   * 단기 예보 API에 데이터를 요청하여 응답을 받아와 리턴한다.
+   *
+   * @param mapper   JSON 변환에 사용할 ObjectMapper
+   * @param baseDate 예보 기준 날짜 (yyyyMMdd)
+   * @param baseTime 예보 기준 시간 (HHmm)
+   * @param nx       예보 지점 X좌표
+   * @param ny       예보 지점 Y좌표
+   * @return API 응답 데이터(ResponseBody)
+   */
   public String fetchWeatherData(
       ObjectMapper mapper, String baseDate, String baseTime, int nx, int ny) {
+    // 기본 파라미터 세팅
     String REQUEST_PARAM_DATA_TYPE = "JSON";
     int REQUEST_PARAM_NUM_OF_ROWS = 1500;
 
+    // 요청 URL 세팅
     String requestUrl = String.format(
         "%s?serviceKey=%s&numOfRows=%d&dataType=%s&base_date=%s&base_time=%s&nx=%d&ny=%d",
         apiProperties.getApiUrl(), apiProperties.getApiServiceKey(),
         REQUEST_PARAM_NUM_OF_ROWS, REQUEST_PARAM_DATA_TYPE, baseDate, baseTime, nx, ny
     );
 
+    // HttpClient 세팅 및 요청 세팅
     HttpClient client = HttpClient.newHttpClient();
     HttpRequest request = HttpRequest.newBuilder()
         .uri(URI.create(requestUrl))
@@ -42,20 +58,23 @@ public class WeatherApiClient {
     try {
       HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
       String resultCode = extractResultCode(mapper, response.body());
+      // 응답 코드가 00이 아니면 비정상적인 응답 (오류)
       if (!"00".equals(resultCode)) {
-        // todo: 예외 처리 필요
-        throw new IllegalStateException("Weather API 응답이 정상적이지 않습니다. resultCode=" + resultCode);
+        log.warn("Weather Api Response Invalid");
+        throw new WeatherApiResponseException(resultCode);
       }
+      // 응답 Body 전달
       return response.body();
     } catch (IOException | InterruptedException e) {
-      // todo: 예외 처리 필요
-      log.error("cause: {}\nmessage: {}", e.getCause(), e.getMessage());
-      throw new RuntimeException();
+      log.error("Weather Api Request Invalid - cause: {}\nmessage: {}", e.getCause(),
+          e.getMessage());
+      throw new WeatherApiRequestException();
     }
   }
 
   private String extractResultCode(ObjectMapper mapper, String responseBody)
       throws IOException {
+    // Header의 resultCode 필드 속 값 String 형태로 추출
     JsonNode root = mapper.readTree(responseBody);
     return root.path("response").path("header").path("resultCode").asText();
   }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/assembler/WeatherAssembler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/assembler/WeatherAssembler.java
@@ -46,24 +46,24 @@ public class WeatherAssembler {
     String fcstTime = helper.extractMinForecastTime(categoryMap);
 
     // 현재 습도 값 파싱
-    double currentHumidity = helper.parseDoubleOrNull(helper.getFcstValue(categoryMap, "REH"));
+    Double currentHumidity = helper.parseDoubleOrNull(helper.getFcstValue(categoryMap, "REH"));
     // 전일 대비 습도 변화랑 계산
-    double comparedHumidity = helper.calculateDifferenceFromPreviousDay(currentHumidity, "REH",
+    Double comparedHumidity = helper.calculateDifferenceFromPreviousDay(currentHumidity, "REH",
         fcstDate, fcstTime,
         groupedApiData);
 
     // todo: 기온 값 등이 없다고 해서 변화량을 0이라고 둬도 되나? null로 두는 것이 나을까? (고민)
     // 현재 기온 값 파싱
-    double currentTemperature = helper.parseDoubleOrNull(helper.getFcstValue(categoryMap, "TMP"));
+    Double currentTemperature = helper.parseDoubleOrNull(helper.getFcstValue(categoryMap, "TMP"));
     // 전일 대비 기온 변화량 계산
-    double comparedTemperature = helper.calculateDifferenceFromPreviousDay(currentTemperature,
+    Double comparedTemperature = helper.calculateDifferenceFromPreviousDay(currentTemperature,
         "TMP", fcstDate, fcstTime,
         groupedApiData);
 
     // 최고 기온 값 파싱 (해당 카테고리가 없을 때는 0)
-    double tmx = helper.parseMinMaxTempDoubleOrZero(categoryMap.get("TMX"));
+    Double tmx = helper.parseMinMaxTempDoubleOrNull(categoryMap.get("TMX"));
     // 최저 기온 값 파싱 (해당 카테고리가 없을 때는 0)
-    double tmn = helper.parseMinMaxTempDoubleOrZero(categoryMap.get("TMN"));
+    Double tmn = helper.parseMinMaxTempDoubleOrNull(categoryMap.get("TMN"));
 
     // Weather 엔티티 생성
     return Weather.builder()

--- a/src/main/java/com/codeit/weatherwear/domain/weather/assembler/WeatherAssembler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/assembler/WeatherAssembler.java
@@ -15,12 +15,26 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+/**
+ * Weather 엔티티를 조립하는 Assembler 클래스
+ */
 @Component
 @RequiredArgsConstructor
 public class WeatherAssembler {
 
+  // 복잡한 계산 및 파싱 로직 분리
   private final WeatherCalculationHelper helper;
 
+  /**
+   * 주어진 예보 데이터와 위치 정보를 바탕으로 Weather 엔티티를 조립(assemble)하여 반환한다.
+   *
+   * @param fcstDate       예보 날짜 (yyyyMMdd)
+   * @param baseDate       기준 날짜 (yyyyMMdd)
+   * @param categoryMap    카테고리별(예: TMP, REH 등) WeatherApiData 맵
+   * @param location       위치 정보 엔티티
+   * @param groupedApiData 날짜별/카테고리별로 그룹화된 WeatherApiData 맵
+   * @return Weather 엔티티 객체
+   */
   public Weather assemble(
       String fcstDate,
       String baseDate,
@@ -28,26 +42,30 @@ public class WeatherAssembler {
       Location location,
       Map<String, Map<String, List<WeatherApiData>>> groupedApiData
   ) {
+    // categoryMap에서 예보 시간 중 가장 이른(fcstTime) 값을 추출
     String fcstTime = helper.extractMinForecastTime(categoryMap);
 
-    Double currentHumidity = helper.parseDoubleOrNull(helper.getFcstValue(categoryMap, "REH"));
-    Double comparedHumidity = (currentHumidity != null)
-        ? helper.calculateDifferenceFromPreviousDay(currentHumidity, "REH", fcstDate, fcstTime,
-        groupedApiData)
-        : null;
+    // 현재 습도 값 파싱
+    double currentHumidity = helper.parseDoubleOrNull(helper.getFcstValue(categoryMap, "REH"));
+    // 전일 대비 습도 변화랑 계산
+    double comparedHumidity = helper.calculateDifferenceFromPreviousDay(currentHumidity, "REH",
+        fcstDate, fcstTime,
+        groupedApiData);
 
-    Double currentTemperature = helper.parseDoubleOrNull(helper.getFcstValue(categoryMap, "TMP"));
-    Double comparedTemperature = (currentTemperature != null)
-        ? helper.calculateDifferenceFromPreviousDay(currentTemperature, "TMP", fcstDate, fcstTime,
-        groupedApiData)
-        : null;
+    // todo: 기온 값 등이 없다고 해서 변화량을 0이라고 둬도 되나? null로 두는 것이 나을까? (고민)
+    // 현재 기온 값 파싱
+    double currentTemperature = helper.parseDoubleOrNull(helper.getFcstValue(categoryMap, "TMP"));
+    // 전일 대비 기온 변화량 계산
+    double comparedTemperature = helper.calculateDifferenceFromPreviousDay(currentTemperature,
+        "TMP", fcstDate, fcstTime,
+        groupedApiData);
 
-    WeatherApiData tmxData = categoryMap.get("TMX");
-    Double tmx = (tmxData != null) ? Double.parseDouble(tmxData.getFcstValue()) : 0;
+    // 최고 기온 값 파싱 (해당 카테고리가 없을 때는 0)
+    double tmx = helper.parseMinMaxTempDoubleOrZero(categoryMap.get("TMX"));
+    // 최저 기온 값 파싱 (해당 카테고리가 없을 때는 0)
+    double tmn = helper.parseMinMaxTempDoubleOrZero(categoryMap.get("TMN"));
 
-    WeatherApiData tmnData = categoryMap.get("TMN");
-    Double tmn = (tmnData != null) ? Double.parseDouble(tmnData.getFcstValue()) : 0;
-
+    // Weather 엔티티 생성
     return Weather.builder()
         .location(location)
         .forecastedAt(helper.toInstant(baseDate, categoryMap.get("REH").getId().getBaseTime()))

--- a/src/main/java/com/codeit/weatherwear/domain/weather/assembler/WeatherAssembler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/assembler/WeatherAssembler.java
@@ -74,8 +74,9 @@ public class WeatherAssembler {
         .precipitation(
             Precipitation.builder()
                 .type(PrecipitationsType.fromCode(categoryMap.get("PTY").getFcstValue()))
-                .amount(helper.parsePrecipitation(categoryMap.get("PCP").getFcstValue()))
-                .probability(Double.parseDouble(categoryMap.get("POP").getFcstValue()))
+                .amount(helper.parsePrecipitationAmount(categoryMap.get("PCP").getFcstValue()))
+                .probability(
+                    helper.parsePrecipitationProbability(categoryMap.get("POP").getFcstValue()))
                 .build()
         )
         .humidity(

--- a/src/main/java/com/codeit/weatherwear/domain/weather/dto/response/HumidityDto.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/dto/response/HumidityDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Builder
 public class HumidityDto {
 
-  private final double current;
-  private final double comparedToDayBefore;
+  private final Double current;
+  private final Double comparedToDayBefore;
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/dto/response/PrecipitationDto.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/dto/response/PrecipitationDto.java
@@ -9,6 +9,6 @@ import lombok.Getter;
 public class PrecipitationDto {
 
   private final PrecipitationsType type;  // 강수 타입
-  private final double amount;  // 강수량
-  private final double probability; // 강수 확률
+  private final Double amount;  // 강수량
+  private final Double probability; // 강수 확률
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/dto/response/TemperatureDto.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/dto/response/TemperatureDto.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 @Builder
 public class TemperatureDto {
 
-  private final double current;
-  private final double comparedToDayBefore;
-  private final double min;
-  private final double max;
+  private final Double current;
+  private final Double comparedToDayBefore;
+  private final Double min;
+  private final Double max;
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/dto/response/WindSpeedDto.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/dto/response/WindSpeedDto.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 @Builder
 public class WindSpeedDto {
 
-  private final double speed;
+  private final Double speed;
   private final WindSpeedType asWord;
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/entity/Humidity.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/entity/Humidity.java
@@ -20,17 +20,17 @@ public class Humidity {
   @Comment("습도 (%)")
   @Min(value = 0, message = "현재 습도는 음수가 될 수 없습니다.")
   @Max(value = 100, message = "현재 습도는 100%를 초과할 수 없습니다.")
-  @Column(name = "humidity_current", nullable = false)
-  private double current;
+  @Column(name = "humidity_current")
+  private Double current;
 
   @Comment("전일 대비 습도 (%)")
   @Min(value = -100, message = "전일 대비 습도는 -100%보다 더 낮은 값이 될 수 없습니다.")
   @Max(value = 100, message = "전일 대비 습도는 100%보다 더 높은 값이 될 수 없습니다.")
-  @Column(name = "humidity_compared_to_day_before", nullable = false)
-  private double comparedToDayBefore;
+  @Column(name = "humidity_compared_to_day_before")
+  private Double comparedToDayBefore;
 
   @Builder
-  private Humidity(double comparedToDayBefore, double current) {
+  private Humidity(Double comparedToDayBefore, Double current) {
     this.comparedToDayBefore = comparedToDayBefore;
     this.current = current;
   }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/entity/Precipitation.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/entity/Precipitation.java
@@ -21,22 +21,22 @@ public class Precipitation {
 
   @Enumerated(EnumType.STRING)
   @Comment("강수 형태")
-  @Column(name = "precipitation_type", nullable = false)
+  @Column(name = "precipitation_type")
   private PrecipitationsType type;
 
   @Comment("시간당 강수량 - 범주 (1 mm)")
   @Min(value = 0, message = "강수량은 음수가 될 수 없습니다.")
-  @Column(name = "precipitation_amount", nullable = false)
-  private double amount;
+  @Column(name = "precipitation_amount")
+  private Double amount;
 
   @Comment("강수 확률 (%)")
   @Min(value = 0, message = "강수 확률은 음수가 될 수 없습니다.")
-  @Max(value = 100, message = "강수 확률은 100%를 초과할 수 없습니다.")
-  @Column(name = "precipitation_probability", nullable = false)
-  private double probability;
+  @Max(value = 1, message = "강수 확률은 100%를 초과할 수 없습니다.")
+  @Column(name = "precipitation_probability")
+  private Double probability;
 
   @Builder
-  private Precipitation(double probability, double amount, PrecipitationsType type) {
+  private Precipitation(Double probability, Double amount, PrecipitationsType type) {
     this.probability = probability;
     this.amount = amount;
     this.type = type;

--- a/src/main/java/com/codeit/weatherwear/domain/weather/entity/Temperature.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/entity/Temperature.java
@@ -14,23 +14,23 @@ import org.hibernate.annotations.Comment;
 public class Temperature {
 
   @Comment("현재 온도(섭씨)")
-  @Column(name = "temperature_current", nullable = false)
-  private double current;
+  @Column(name = "temperature_current")
+  private Double current;
 
   @Comment("전일 대비 온도(섭씨)")
-  @Column(name = "temperature_compared_to_day_before", nullable = false)
-  private double comparedToDayBefore;
+  @Column(name = "temperature_compared_to_day_before")
+  private Double comparedToDayBefore;
 
   @Comment("일 최저 기온(섭씨)")
-  @Column(name = "temperature_min", nullable = false)
-  private double min;
+  @Column(name = "temperature_min")
+  private Double min;
 
   @Comment("일 최고 기온(섭씨)")
-  @Column(name = "temperature_max", nullable = false)
-  private double max;
+  @Column(name = "temperature_max")
+  private Double max;
 
   @Builder
-  private Temperature(double current, double comparedToDayBefore, double min, double max) {
+  private Temperature(Double current, Double comparedToDayBefore, Double min, Double max) {
     this.current = current;
     this.comparedToDayBefore = comparedToDayBefore;
     this.min = min;

--- a/src/main/java/com/codeit/weatherwear/domain/weather/entity/Weather.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/entity/Weather.java
@@ -44,7 +44,7 @@ public class Weather {
   private Instant forecastAt;
 
   @Enumerated(EnumType.STRING)
-  @Column(name = "sky_status", length = 20, nullable = false)
+  @Column(name = "sky_status", length = 20)
   private SkyStatus skyStatus;
 
   @Embedded

--- a/src/main/java/com/codeit/weatherwear/domain/weather/entity/WindSpeed.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/entity/WindSpeed.java
@@ -18,11 +18,11 @@ public class WindSpeed {
 
   @Comment("풍속 단위: m/s")
   @Min(value = 0, message = "풍속은 음수가 될 수 없습니다.")
-  @Column(name = "wind_speed", nullable = false)
-  private double speed;
+  @Column(name = "wind_speed")
+  private Double speed;
 
   @Enumerated(EnumType.STRING)
-  @Column(name = "wind_speed_as_word", nullable = false)
+  @Column(name = "wind_speed_as_word")
   private WindSpeedType speedAsWord;
 
   @Builder

--- a/src/main/java/com/codeit/weatherwear/domain/weather/exception/WeatherApiParsingException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/exception/WeatherApiParsingException.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.domain.weather.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+
+public class WeatherApiParsingException extends CustomException {
+
+  public WeatherApiParsingException() {
+    super(ErrorCode.WEATHER_API_PARSING_FAILED);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/exception/WeatherApiRequestException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/exception/WeatherApiRequestException.java
@@ -1,0 +1,11 @@
+package com.codeit.weatherwear.domain.weather.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+
+public class WeatherApiRequestException extends CustomException {
+
+  public WeatherApiRequestException() {
+    super(ErrorCode.WEATHER_API_REQUEST_ERROR);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/exception/WeatherApiResponseException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/exception/WeatherApiResponseException.java
@@ -1,0 +1,12 @@
+package com.codeit.weatherwear.domain.weather.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+import java.util.Map;
+
+public class WeatherApiResponseException extends CustomException {
+
+  public WeatherApiResponseException(String resultCode) {
+    super(ErrorCode.WEATHER_API_RESPONSE_ERROR, Map.of("code", resultCode));
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/parser/WeatherApiParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/parser/WeatherApiParser.java
@@ -2,6 +2,7 @@ package com.codeit.weatherwear.domain.weather.parser;
 
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiData;
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiDataId;
+import com.codeit.weatherwear.domain.weather.exception.WeatherApiParsingException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,52 +24,73 @@ public class WeatherApiParser {
       "WSD"   // 풍속
   );
 
+  /**
+   * 단기예보 API JSON 응답을 파싱하여 WeatherApiData 리스트로 변환한 뒤,<br>예보 날짜(fcstDate) → 예보 시간(fcstTime) 기준으로
+   * 그룹핑하여 반환
+   *
+   * @param mapper       Jackson ObjectMapper
+   * @param responseBody 단기예보 API 응답의 JSON body 문자열
+   * @return 예보 날짜 → 예보 시간 → 해당 시간대 예보 데이터 리스트로 구성된 Map
+   */
   public Map<String, Map<String, List<WeatherApiData>>> parse(ObjectMapper mapper,
       String responseBody) {
     try {
       JsonNode root = mapper.readTree(responseBody); // 전체 JSON
       JsonNode itemsNode = root.path("response").path("body").path("items").path("item");
 
-      List<WeatherApiData> entities = new ArrayList<>();
+      // 엔티티 저장할 리스트
+      List<WeatherApiData> parsedDataList = new ArrayList<>();
 
+      // 아이템들 반복 돌림
       for (JsonNode item : itemsNode) {
         String category = item.path("category").asText();
 
-        if (isTargetCategory(category)) {
-          WeatherApiDataId id = WeatherApiDataId.builder()
-              .baseDate(item.path("baseDate").asText())
-              .baseTime(item.path("baseTime").asText())
-              .category(category)
-              .build();
-
-          WeatherApiData entity = WeatherApiData.builder()
-              .id(id)
-              .fcstDate(item.path("fcstDate").asText())
-              .fcstTime(item.path("fcstTime").asText())
-              .fcstValue(item.path("fcstValue").asText())
-              .nx(item.path("nx").asInt())
-              .ny(item.path("ny").asInt())
-              .build();
-
-          entities.add(entity);
+        // 강수량, 하늘 상태 등 필요한 카테고리만 필터링
+        if (!isTargetCategory(category)) {
+          continue;
         }
+
+        // 타겟 카테고리 및 데이터일 경우, WeatherApiData 생성
+        WeatherApiDataId id = WeatherApiDataId.builder()
+            .baseDate(item.path("baseDate").asText())
+            .baseTime(item.path("baseTime").asText())
+            .category(category)
+            .build();
+
+        WeatherApiData entity = WeatherApiData.builder()
+            .id(id)
+            .fcstDate(item.path("fcstDate").asText())
+            .fcstTime(item.path("fcstTime").asText())
+            .fcstValue(item.path("fcstValue").asText())
+            .nx(item.path("nx").asInt())
+            .ny(item.path("ny").asInt())
+            .build();
+
+        parsedDataList.add(entity);
+
       }
 
-      Map<String, Map<String, List<WeatherApiData>>> grouped =
-          entities.stream()
+      // 예보 날짜 및 예보 시간으로 그룹핑
+      Map<String, Map<String, List<WeatherApiData>>> groupedByDateAndTime =
+          parsedDataList.stream()
               .collect(Collectors.groupingBy(
                   WeatherApiData::getFcstDate,
                   Collectors.groupingBy(WeatherApiData::getFcstTime)
               ));
 
-      return grouped;
+      return groupedByDateAndTime;
 
     } catch (JsonProcessingException jpe) {
-      // todo: 예외 처리
-      throw new RuntimeException();
+      throw new WeatherApiParsingException();
     }
   }
 
+  /**
+   * 타겟 카테고리 (필요한 카테고리인지) 여부 응답
+   *
+   * @param category
+   * @return Boolean
+   */
   private boolean isTargetCategory(String category) {
     return TARGET_CATEGORIES.contains(category);
   }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepository.java
@@ -6,10 +6,14 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WeatherRepository extends JpaRepository<Weather, UUID> {
 
-  List<Weather> findWeathersByLocationAndForecastedAt(Location location, Instant forecastedAt);
+  @Query("SELECT w FROM Weather w WHERE w.location = :location AND w.forecastedAt >= :start")
+  List<Weather> findRecentWeathers(@Param("location") Location location,
+      @Param("start") Instant todayStart);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherConvertServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherConvertServiceImpl.java
@@ -116,7 +116,7 @@ public class WeatherConvertServiceImpl implements WeatherConvertService {
         data -> data.getId().getCategory(),
         Function.identity(),
         // 동일 카테고리 내 fcstTime이 더 늦은(최신) 데이터 선택
-        (d1, d2) -> d1.getFcstTime().compareTo(d2.getFcstTime()) <= 0 ? d1 : d2
+        (d1, d2) -> d1.getFcstTime().compareTo(d2.getFcstTime()) >= 0 ? d1 : d2
     ));
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherConvertServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherConvertServiceImpl.java
@@ -24,11 +24,20 @@ public class WeatherConvertServiceImpl implements WeatherConvertService {
 
   private final WeatherAssembler weatherAssembler;
 
+  /**
+   * 변환 수행 메서드
+   *
+   * @param groupedApiData 예보 날짜 -> 예보 시간 -> 해당 시간대 예보 데이터 리스트로 구성된 Map
+   * @param location       위치 엔티티
+   * @return Weather 엔티티 리스트
+   */
   @Override
   public List<Weather> convert(Map<String, Map<String, List<WeatherApiData>>> groupedApiData,
       Location location) {
     List<Weather> result = new ArrayList<>();
 
+    // groupedApiData 에서 날짜별 데이터를 순회하며 변환 수행 후,
+    // 결과가 존재할 경우 result 에 추가
     for (Map.Entry<String, Map<String, List<WeatherApiData>>> dateEntry : groupedApiData.entrySet()) {
       convertForecastDay(dateEntry.getKey(), dateEntry.getValue(), groupedApiData,
           location).ifPresent(result::add);
@@ -37,21 +46,33 @@ public class WeatherConvertServiceImpl implements WeatherConvertService {
     return result;
   }
 
+  /**
+   * @param fcstDate       예보 날짜 (yyyyMMdd)
+   * @param timeMap        시간별 WeatherApiData 리스트 맵
+   * @param groupedApiData 카테고리별로 그룹화된 WeatherApiData 맵 (fcstDate -> fcstTime -> data)
+   * @param location       위치 정보
+   * @return 변환된 Weather 객체(Optional), 변환 불가 시 Optional.empty()
+   */
   private Optional<Weather> convertForecastDay(
       String fcstDate,
       Map<String, List<WeatherApiData>> timeMap,
       Map<String, Map<String, List<WeatherApiData>>> groupedApiData,
       Location location
   ) {
+    // 시간별 예보 데이터를 평탄화 하여 하나의 리스트로 만듦
     List<WeatherApiData> flatList = timeMap.values().stream()
         .flatMap(List::stream)
         .collect(Collectors.toList());
 
+    // 예보 데이터가 없다면 변환하지 않음
     if (flatList.isEmpty()) {
       return Optional.empty();
     }
 
+    // BaseDate (예보 기준일) 추출
     String baseDate = flatList.get(0).getId().getBaseDate();
+    // 기준일(baseDate)로부터 4일을 초과하는 예보 날짜(fcstDate)는 제외
+    // todo: -> 추후 비동기 등을 적용해봐도 좋을 것 같다
     if (shouldSkipForecastDate(baseDate, fcstDate)) {
       return Optional.empty();
     }
@@ -60,16 +81,23 @@ public class WeatherConvertServiceImpl implements WeatherConvertService {
     Map<String, WeatherApiData> categoryMap = toLatestCategoryMap(flatList);
 
     try {
+      // WeatherAssembler를 이용하여 Weather 객체 생성
       return Optional.ofNullable(
           weatherAssembler.assemble(fcstDate, baseDate, categoryMap, location, groupedApiData));
     } catch (Exception e) {
+      // 변환 실패 시 로그 출력 후 Optional.empty() 반환
       log.error("날짜 {} → 변환 실패: {}", fcstDate, e.getMessage());
-      e.printStackTrace();
       return Optional.empty();
     }
-
   }
 
+  /**
+   * 기준일(baseDate)로부터 4일을 초과하는 예보 날짜(fcstDate)는 제외<br>그 이상을 요청했을 때는 요청 시간이 너무 길어짐 (8s 이상)
+   *
+   * @param baseDateStr   예보기준일, yyyyMMdd 형식의 String
+   * @param targetDateStr 예보대상일, yyyyMMdd 형식의 String
+   * @return 기준일로부터 4일을 초과하는 예보인지 여부 (Boolean)
+   */
   private boolean shouldSkipForecastDate(String baseDateStr, String targetDateStr) {
     LocalDate base = LocalDate.parse(baseDateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
     LocalDate target = LocalDate.parse(targetDateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
@@ -77,10 +105,17 @@ public class WeatherConvertServiceImpl implements WeatherConvertService {
     // 기준일로부터 4일을 넘으면 제외
   }
 
+  /**
+   * 예보 카테고리별로 가장 최신(fcstTime 기준) 데이터 추출
+   *
+   * @param flatList 하나의 날짜에 대한 모든 예보 데이터(평탄화된 WeatherApiData 리스트)
+   * @return 카테고리별 최신 WeatherApiData 맵
+   */
   private Map<String, WeatherApiData> toLatestCategoryMap(List<WeatherApiData> flatList) {
     return flatList.stream().collect(Collectors.toMap(
         data -> data.getId().getCategory(),
         Function.identity(),
+        // 동일 카테고리 내 fcstTime이 더 늦은(최신) 데이터 선택
         (d1, d2) -> d1.getFcstTime().compareTo(d2.getFcstTime()) <= 0 ? d1 : d2
     ));
   }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImpl.java
@@ -24,15 +24,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 기상청 단기 예보 API 요청부터 응답 파싱 후 Weather 엔티티 변환까지<br>전반적인 프로세스를 정의하는 서비스 클래스
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class WeatherFetchServiceImpl implements WeatherFetchService {
 
-  private final String ZONE_ID = "Asia/Seoul";
+  // todo: KST 너무 여러 클래스에서 많이 쓰임
+  private final ZoneId KST = ZoneId.of("Asia/Seoul");
+  // todo: 이것도 String 말고 다른 방식으로 하는게 좋지 않을까 하는 생각이 잠시 든다 -> Enum으로 수정하고 안에 메서드로 String으로 바꾸는 걸 넣는 것은?
   private final List<String> ALLOWED_BASE_TIME = List.of(
       "0200", "0500", "0800", "1100", "1400", "1700", "2000", "2300"
   );
+
   private final LocationService locationService;
   private final WeatherConvertService weatherConvertService;
   private final WeatherRepository weatherRepository;
@@ -40,6 +46,13 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
   private final WeatherApiClient weatherApiClient;
   private final WeatherApiParser weatherApiParser;
 
+  /**
+   * 기상청 단기 예보 API 요청 및 데이터 파싱을 거쳐 나온<br>날씨 데이터를 저장하고 반환
+   *
+   * @param latitude  위도
+   * @param longitude 경도
+   * @return 날씨 엔티티 리스트
+   */
   @Transactional
   @Override
   public List<Weather> fetchAndStoreWeather(double latitude, double longitude) {
@@ -48,35 +61,59 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
     String baseTime = getBaseTime(now);
 
     ObjectMapper mapper = new ObjectMapper();
+
+    // 위치 엔티티 조회, 존재하지 않을 시 생성
     Location location = locationService.findOrCreateByGeoPoint(latitude, longitude);
 
+    // 단기 예보 API 요청 후 응답 Body 값 반환
     String responseBody = weatherApiClient.fetchWeatherData(mapper, baseDate, baseTime,
         location.getX(), location.getY());
 
+    // 응답 Body 값 파싱하여 Map[예보 날짜,Map[예보 타입(POP 등), 예보 RAW 데이터]] 으로 반환
     Map<String, Map<String, List<WeatherApiData>>> parsedWeatherApi = weatherApiParser.parse(mapper,
         responseBody);
 
+    // 파싱한 데이터를 Weather 엔티티에 맞게 변환 후 저장
     List<Weather> weatherList = weatherConvertService.convert(parsedWeatherApi, location);
     weatherRepository.saveAll(weatherList);
+
+    // Weather 리스트 반환
     return weatherList;
   }
 
+  /**
+   * Base Date 설정
+   *
+   * @param base Instant 객체
+   * @return yyyyMMdd 형식의 기준 날짜 문자열
+   */
   private String getBaseDate(Instant base) {
-    return LocalDateTime.ofInstant(base, ZoneId.of("Asia/Seoul"))
+    return LocalDateTime.ofInstant(base, KST)
         .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
   }
 
+  /**
+   * Base Time 설정
+   *
+   * @param base Instant 객체
+   * @return HHmm 형식의 기준 시간 문자열
+   */
   private String getBaseTime(Instant base) {
     final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmm");
 
-    LocalTime localTime = LocalDateTime.ofInstant(base, ZoneId.of(ZONE_ID)).toLocalTime();
+    LocalTime localTime = LocalDateTime.ofInstant(base, KST).toLocalTime();
 
+    // 현재 시각 이전(baseTime ≤ 현재시간) 중 가장 가까운 baseTime 을 찾아 "HHmm" 형식으로 반환
+    // 단, 없을 경우 기본값 "2300" 반환
     return ALLOWED_BASE_TIME.stream()
         .map(t -> LocalTime.parse(t, TIME_FORMATTER))
+        // 현재보다 이전/같은 시간만 필터링
         .filter(t -> !t.isAfter(localTime))
+        // 가장 가까운 BaseTime 선택
         .min(Comparator.comparingInt(
             t -> Math.abs((int) Duration.between(localTime, t).toMinutes())))
         .map(t -> t.format(DateTimeFormatter.ofPattern("HHmm")))
+        // 아무것도 없으면 기본 값 제공
         .orElse("2300");
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherServiceImpl.java
@@ -36,6 +36,13 @@ public class WeatherServiceImpl implements WeatherService {
 
   private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
+  /**
+   * 날씨 정보 요청 API
+   *
+   * @param latitude  위도
+   * @param longitude 경도
+   * @return WeatherDto 리스트 반환
+   */
   @Transactional
   @Override
   public List<WeatherDto> getWeatherInfo(double latitude, double longitude) {
@@ -59,6 +66,13 @@ public class WeatherServiceImpl implements WeatherService {
         Collectors.toList());
   }
 
+  /**
+   * 위치 정보 요청 API
+   *
+   * @param latitude  위도
+   * @param longitude 경도
+   * @return LocationDto 반환
+   */
   @Transactional
   @Override
   public LocationDto getLocationInfo(double latitude, double longitude) {

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherServiceImpl.java
@@ -52,8 +52,7 @@ public class WeatherServiceImpl implements WeatherService {
     LocalDate today = LocalDate.now(KST);
 
     Instant todayStart = today.atStartOfDay(KST).toInstant();    // 오늘 00:00
-    List<Weather> weatherList = weatherRepository.findWeathersByLocationAndForecastedAt(location,
-        todayStart);
+    List<Weather> weatherList = weatherRepository.findRecentWeathers(location, todayStart);
 
     if (weatherList.isEmpty()) {
       // 없다면 가져오기

--- a/src/main/java/com/codeit/weatherwear/domain/weather/support/WeatherCalculationHelper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/support/WeatherCalculationHelper.java
@@ -33,6 +33,10 @@ public class WeatherCalculationHelper {
   private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmm");
   private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
+  private static final String DEFAULT_TIME = "1100";
+  private static final String NO_PRECIPITATION = "강수없음";
+
+
   /**
    * 주어진 날짜와 시간 문자열을 KST 기준 {@link Instant} 로 변환합니다.
    *
@@ -96,15 +100,15 @@ public class WeatherCalculationHelper {
    * @param value 강수량 문자열
    * @return 실수형 강수량 (mm)
    */
-  public double parsePrecipitation(String value) {
-    if (value == null || value.equals("강수없음")) {
-      return 0.0;
+  public Double parsePrecipitation(String value) {
+    if (value == null || value.equals(NO_PRECIPITATION)) {
+      return null;
     }
     try {
       return Double.parseDouble(value);
     } catch (NumberFormatException e) {
       log.warn("Failed Precipitation Parsing - {}", value);
-      return 0.0;
+      return null;
     }
   }
 
@@ -118,10 +122,14 @@ public class WeatherCalculationHelper {
    * @param groupedApiData 날짜 및 시간별 그룹화된 예보 데이터
    * @return 전일 대비 변화량 (예보값이 없으면 현재값과 동일하다고 가정 → 차이 0)
    */
-  public double calculateDifferenceFromPreviousDay(
-      double current, String category, String fcstDate, String fcstTime,
+  public Double calculateDifferenceFromPreviousDay(
+      Double current, String category, String fcstDate, String fcstTime,
       Map<String, Map<String, List<WeatherApiData>>> groupedApiData
   ) {
+    if (current == null) {
+      return null;
+    }
+
     // 전날 날짜 계산
     LocalDate previousDate = LocalDate.parse(fcstDate, DATE_FORMATTER).minusDays(1);
     String previousDateStr = previousDate.format(DATE_FORMATTER);
@@ -149,7 +157,7 @@ public class WeatherCalculationHelper {
     return categoryMap.values().stream()
         .map(WeatherApiData::getFcstTime)
         .min(String::compareTo)
-        .orElse("1100");
+        .orElse(DEFAULT_TIME);
   }
 
   /**
@@ -158,8 +166,8 @@ public class WeatherCalculationHelper {
    * @param data 카테고리별 WeatherApiData
    * @return Double로 파싱된 데이터 값
    */
-  public double parseMinMaxTempDoubleOrZero(WeatherApiData data) {
-    return data != null ? Double.parseDouble(data.getFcstValue()) : 0;
+  public Double parseMinMaxTempDoubleOrNull(WeatherApiData data) {
+    return data != null ? Double.parseDouble(data.getFcstValue()) : null;
   }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/support/WeatherCalculationHelper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/support/WeatherCalculationHelper.java
@@ -100,7 +100,7 @@ public class WeatherCalculationHelper {
    * @param value 강수량 문자열
    * @return 실수형 강수량 (mm)
    */
-  public Double parsePrecipitation(String value) {
+  public Double parsePrecipitationAmount(String value) {
     if (value == null || value.equals(NO_PRECIPITATION)) {
       return null;
     }
@@ -108,6 +108,18 @@ public class WeatherCalculationHelper {
       return Double.parseDouble(value);
     } catch (NumberFormatException e) {
       log.warn("Failed Precipitation Parsing - {}", value);
+      return null;
+    }
+  }
+
+  public Double parsePrecipitationProbability(String value) {
+    if (value == null) {
+      return null;
+    }
+    try {
+      return Double.parseDouble(value) * 0.01;
+    } catch (NumberFormatException e) {
+      log.warn("Failed Precipitation Probability Parsing - {}", value);
       return null;
     }
   }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/support/WeatherCalculationHelper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/support/WeatherCalculationHelper.java
@@ -11,8 +11,21 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+/**
+ * 엔티티 생성 시 필요한 복잡한 계산 및 파싱 로직을 분리한 헬퍼 클래스
+ * <p>
+ * - 날짜 및 시간 파싱
+ * <p>
+ * - 카테고리 기반 값 추출
+ * <p>
+ * - 값 변환 및 예외 처리
+ * <p>
+ * - 전일 대비 값 계산
+ */
+@Slf4j
 @Component
 public class WeatherCalculationHelper {
 
@@ -21,7 +34,11 @@ public class WeatherCalculationHelper {
   private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
   /**
-   * 날짜 + 시간 문자열을 Instant(KST)로 변환
+   * 주어진 날짜와 시간 문자열을 KST 기준 {@link Instant} 로 변환합니다.
+   *
+   * @param date 날짜 (형식: yyyyMMdd)
+   * @param time 시간 (형식: HHmm)
+   * @return 변환된 Instant 객체 (KST 기준)
    */
   public Instant toInstant(String date, String time) {
     return LocalDateTime.of(
@@ -30,11 +47,27 @@ public class WeatherCalculationHelper {
     ).atZone(KST).toInstant();
   }
 
+  /**
+   * 주어진 key에 해당하는 예보값(fcstValue)을 반환합니다.
+   *
+   * @param map 카테고리별 WeatherApiData 맵
+   * @param key 추출할 카테고리 코드 (예: TMP, REH 등)
+   * @return 예보값 문자열, 존재하지 않으면 null
+   */
+
   public String getFcstValue(Map<String, WeatherApiData> map, String key) {
     return Optional.ofNullable(map.get(key))
         .map(WeatherApiData::getFcstValue)
         .orElse(null);
   }
+
+  /**
+   * 주어진 key에 해당하는 baseTime(예보 기준 시간)을 반환합니다.
+   *
+   * @param map 카테고리별 WeatherApiData 맵
+   * @param key 추출할 카테고리 코드
+   * @return baseTime 문자열, 존재하지 않으면 기본값 "1100"
+   */
 
   public String getBaseTime(Map<String, WeatherApiData> map, String key) {
     return Optional.ofNullable(map.get(key))
@@ -42,16 +75,26 @@ public class WeatherCalculationHelper {
         .orElse("1100");
   }
 
+  /**
+   * 문자열을 Double로 파싱합니다.<br>null 또는 잘못된 숫자 형식이면 null을 반환합니다.
+   *
+   * @param value 문자열 값
+   * @return Double 객체 또는 null
+   */
   public Double parseDoubleOrNull(String value) {
     try {
       return value != null ? Double.parseDouble(value) : null;
     } catch (NumberFormatException e) {
+      log.warn("Failed Double Parsing - {}", value);
       return null;
     }
   }
 
   /**
-   * 강수량 문자열 변환 ("강수없음" → 0.0)
+   * 강수량 문자열을 실수로 변환합니다. "강수없음" 또는 null은 0.0으로 처리합니다.
+   *
+   * @param value 강수량 문자열
+   * @return 실수형 강수량 (mm)
    */
   public double parsePrecipitation(String value) {
     if (value == null || value.equals("강수없음")) {
@@ -60,31 +103,35 @@ public class WeatherCalculationHelper {
     try {
       return Double.parseDouble(value);
     } catch (NumberFormatException e) {
+      log.warn("Failed Precipitation Parsing - {}", value);
       return 0.0;
     }
   }
 
   /**
-   * 전날 같은 시간대의 예보값과 비교하여 변화량 계산
+   * 현재 값과 전날 같은 시간대 예보값의 차이를 계산합니다.
    *
    * @param current        현재 값
-   * @param category       카테고리 코드 - "REH", "TMP"
-   * @param fcstDate       예보일
-   * @param fcstTime       예보시간
-   * @param groupedApiData 날짜+시간별 그룹핑된 데이터
-   * @return 전날 대비 변화량 (없을 경우 0)
+   * @param category       카테고리 코드 (예: "REH", "TMP")
+   * @param fcstDate       예보 날짜 (yyyyMMdd)
+   * @param fcstTime       예보 시간 (HHmm)
+   * @param groupedApiData 날짜 및 시간별 그룹화된 예보 데이터
+   * @return 전일 대비 변화량 (예보값이 없으면 현재값과 동일하다고 가정 → 차이 0)
    */
   public double calculateDifferenceFromPreviousDay(
       double current, String category, String fcstDate, String fcstTime,
       Map<String, Map<String, List<WeatherApiData>>> groupedApiData
   ) {
+    // 전날 날짜 계산
     LocalDate previousDate = LocalDate.parse(fcstDate, DATE_FORMATTER).minusDays(1);
     String previousDateStr = previousDate.format(DATE_FORMATTER);
 
+    // 전날 같은 시간의 예보 리스트 가져오기
     List<WeatherApiData> previousList = Optional.ofNullable(groupedApiData.get(previousDateStr))
         .map(map -> map.get(fcstTime))
         .orElse(Collections.emptyList());
 
+    // 해당 카테고리에 해당하는 전날 예보값을 찾아 변화량 계산
     return previousList.stream()
         .filter(data -> category.equals(data.getId().getCategory()))
         .mapToDouble(data -> Double.parseDouble(data.getFcstValue()))
@@ -93,14 +140,26 @@ public class WeatherCalculationHelper {
   }
 
   /**
-   * @param categoryMap
-   * @return
+   * 주어진 카테고리 Map에서 가장 이른 예보 시간(fcstTime)을 추출합니다.
+   *
+   * @param categoryMap 카테고리별 WeatherApiData 맵
+   * @return 가장 빠른 fcstTime 값, 없으면 기본값 "1100"
    */
   public String extractMinForecastTime(Map<String, WeatherApiData> categoryMap) {
     return categoryMap.values().stream()
         .map(WeatherApiData::getFcstTime)
         .min(String::compareTo)
         .orElse("1100");
+  }
+
+  /**
+   * 최고/최소 기온 값을 파싱합니다.<br>만약 해당 카테고리에 해당하는 데이터가 없을 때에는 0을 반환합니다.
+   *
+   * @param data 카테고리별 WeatherApiData
+   * @return Double로 파싱된 데이터 값
+   */
+  public double parseMinMaxTempDoubleOrZero(WeatherApiData data) {
+    return data != null ? Double.parseDouble(data.getFcstValue()) : 0;
   }
 
 }

--- a/src/main/java/com/codeit/weatherwear/global/exception/ErrorCode.java
+++ b/src/main/java/com/codeit/weatherwear/global/exception/ErrorCode.java
@@ -44,6 +44,12 @@ public enum ErrorCode {
 
   // WEATHER
   INVALID_WIND_SPEED(HttpStatus.BAD_REQUEST, "유효하지 않은 풍속", "풍속은 0 이상의 값이어야 합니다."),
+  WEATHER_API_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "날씨 API 응답 오류",
+      "날씨 API가 정상적인 응답을 반환하지 않았습니다."),
+  WEATHER_API_REQUEST_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "날씨 API 요청 실패",
+      "날씨 API 요청 중 네트워크 오류 또는 인터럽트가 발생했습니다."),
+  WEATHER_API_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "단기 예보 JSON 파싱 실패",
+      "단기 예보 JSON 파싱 중 오류가 발생하여 실패하였습니다."),
 
   // JWT
   JWTSESSION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증 정보 확인 실패", "토큰이 만료되거나 로그아웃되었습니다."),

--- a/src/main/java/com/codeit/weatherwear/global/exception/ErrorCode.java
+++ b/src/main/java/com/codeit/weatherwear/global/exception/ErrorCode.java
@@ -26,6 +26,16 @@ public enum ErrorCode {
   SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우 할 수 없습니다.", ""),
   FOLLOW_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 팔로우한 사용자입니다.", ""),
 
+  // LOCATION
+  KAKAO_GEO_API_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API 응답 오류",
+      "카카오 주소 정보 요청에 대한 정상적인 응답을 반환하지 않았습니다."),
+  KAKAO_GEO_API_REQUEST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API 요청 중 오류",
+      "카카오 주소 정보 요청 중 오류가 발생하였습니다."),
+  LOCATION_NOT_FOUND_BY_GEO_POINT(HttpStatus.NOT_FOUND, "위치 조회 실패", "존재하지 않는 위치 엔티티입니다."),
+  ADDRESS_FIELD_NOT_FOUND(HttpStatus.NOT_FOUND, "주소 정보 확인 실패", "응답 JSON에서 주소 노드를 찾을 수 없습니다."),
+  ADDRESS_JSON_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "주소 JSON 파싱 실패",
+      "주소 응답 데이터를 파싱하는 도중 오류가 발생했습니다."),
+
   // FEED
   FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "피드 조회 실패", "존재하지 않는 피드입니다."),
   UNSUPPORTED_SORT_FIELD(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 필드", "지원하지 않는 정렬 필드입니다."),
@@ -44,7 +54,6 @@ public enum ErrorCode {
   ATTRIBUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "속성 확인 실패", "존재하지 않는 속성입니다."),
   SELECTABLE_DUPLICATE(HttpStatus.BAD_REQUEST, "속성 값 중복 등록", "중복된 속성 값이 존재합니다."),
   INVALID_ATTRIBUTE_NAME(HttpStatus.BAD_REQUEST, "잘못된 속성명입니다.", "정보를 찾을 수 없습니다."),
-
 
   //CLOTH
   CLOTH_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "옷 등록 실패", "존재하는 옷입니다."),

--- a/src/test/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepositoryTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/clothes/repository/ClothRepositoryTest.java
@@ -26,159 +26,162 @@ import org.springframework.test.context.ActiveProfiles;
 @Import(JpaConfig.class)
 public class ClothRepositoryTest {
 
-    @Autowired
-    private ClothRepository sut;
+  @Autowired
+  private ClothRepository sut;
 
-    @Autowired
-    private UserRepository userRepository;
+  @Autowired
+  private UserRepository userRepository;
 
-    @Autowired
-    private AttributeRepository attributeRepository;
-    User user;
-    Cloth thinScarf;
-    Cloth whiteScarf;
-    Cloth redScarf;
-    Attribute color;
-    Attribute thick;
+  @Autowired
+  private AttributeRepository attributeRepository;
+  User user;
+  Cloth thinScarf;
+  Cloth whiteScarf;
+  Cloth redScarf;
+  Attribute color;
+  Attribute thick;
 
-    @BeforeEach
-    void setUp() {
-        user = User.builder()
-            .email("user@test.com")
-            .name("user")
-            .password("user1234!")
-            .build();
-        userRepository.save(user);
+  @BeforeEach
+  void setUp() throws InterruptedException {
+    user = User.builder()
+        .email("user@test.com")
+        .name("user")
+        .password("user1234!")
+        .build();
+    userRepository.save(user);
 
-        color = attributeRepository.save(Attribute.builder()
-            .name("색상")
-            .selectableValues(List.of("빨강", "파랑","하양"))
-            .build());
+    color = attributeRepository.save(Attribute.builder()
+        .name("색상")
+        .selectableValues(List.of("빨강", "파랑", "하양"))
+        .build());
 
-        thick = attributeRepository.save(Attribute.builder()
-            .name("두께")
-            .selectableValues(List.of("두꺼움", "얇음")).build());
+    thick = attributeRepository.save(Attribute.builder()
+        .name("두께")
+        .selectableValues(List.of("두꺼움", "얇음")).build());
 
-        ClothWithAttributes white = ClothWithAttributes.builder()
-            .value("하양")
-            .attribute(color)
-            .build();
+    ClothWithAttributes white = ClothWithAttributes.builder()
+        .value("하양")
+        .attribute(color)
+        .build();
 
-        ClothWithAttributes red = ClothWithAttributes.builder()
-            .value("빨강")
-            .attribute(color)
-            .build();
+    ClothWithAttributes red = ClothWithAttributes.builder()
+        .value("빨강")
+        .attribute(color)
+        .build();
 
-        ClothWithAttributes thin = ClothWithAttributes.builder()
-            .value("얇음")
-            .attribute(thick)
-            .build();
+    ClothWithAttributes thin = ClothWithAttributes.builder()
+        .value("얇음")
+        .attribute(thick)
+        .build();
 
-        thinScarf= Cloth.builder()
-            .name("얇은 스카프")
-            .clothType(ClothType.SCARF)
-            .user(user)
-            .build();
-        thinScarf.addAttribute(white);
-        thinScarf.addAttribute(thin);
+    thinScarf = Cloth.builder()
+        .name("얇은 스카프")
+        .clothType(ClothType.SCARF)
+        .user(user)
+        .build();
+    thinScarf.addAttribute(white);
+    thinScarf.addAttribute(thin);
 
-        whiteScarf= Cloth.builder()
-            .name("하얀 스카프")
-            .clothType(ClothType.SCARF)
-            .user(user)
-            .build();
-        whiteScarf.addAttribute(white);
+    whiteScarf = Cloth.builder()
+        .name("하얀 스카프")
+        .clothType(ClothType.SCARF)
+        .user(user)
+        .build();
+    whiteScarf.addAttribute(white);
 
-        redScarf= Cloth.builder()
-            .name("빨간 스카프")
-            .clothType(ClothType.SCARF)
-            .user(user)
-            .build();
-        redScarf.addAttribute(red);
+    redScarf = Cloth.builder()
+        .name("빨간 스카프")
+        .clothType(ClothType.SCARF)
+        .user(user)
+        .build();
+    redScarf.addAttribute(red);
 
-        sut.save(thinScarf);
-        sut.save(whiteScarf);
-        sut.save(redScarf);
-    }
+    // todo: 테스트 통과를 위해 수정한 부분
+    sut.save(thinScarf);
+    Thread.sleep(10);
+    sut.save(whiteScarf);
+    Thread.sleep(10);
+    sut.save(redScarf);
+  }
 
-    @Test
-    @DisplayName("저장 성공")
-    void save_success() {
-        // given
-        Cloth clothes = Cloth.builder()
-            .name("후드티")
-            .clothType(ClothType.TOP)
-            .user(user)
-            .build();
+  @Test
+  @DisplayName("저장 성공")
+  void save_success() {
+    // given
+    Cloth clothes = Cloth.builder()
+        .name("후드티")
+        .clothType(ClothType.TOP)
+        .user(user)
+        .build();
 
-        ClothWithAttributes attr = ClothWithAttributes.builder()
-            .value("파랑")
-            .attribute(color)
-            .build();
+    ClothWithAttributes attr = ClothWithAttributes.builder()
+        .value("파랑")
+        .attribute(color)
+        .build();
 
-        clothes.addAttribute(attr);
+    clothes.addAttribute(attr);
 
-        // when
-        Cloth saved = sut.save(clothes);
+    // when
+    Cloth saved = sut.save(clothes);
 
-        // then
-        assertThat(saved.getId()).isNotNull();
-        assertThat(saved.getName()).isEqualTo("후드티");
-        assertThat(saved.getClothesWithAttributes()).hasSize(1);
-        assertThat(saved.getClothesWithAttributes().get(0).getValue()).isEqualTo("파랑");
-        assertThat(saved.getUser().getId()).isEqualTo(user.getId());
-    }
+    // then
+    assertThat(saved.getId()).isNotNull();
+    assertThat(saved.getName()).isEqualTo("후드티");
+    assertThat(saved.getClothesWithAttributes()).hasSize(1);
+    assertThat(saved.getClothesWithAttributes().get(0).getValue()).isEqualTo("파랑");
+    assertThat(saved.getUser().getId()).isEqualTo(user.getId());
+  }
 
-    @Test
-    @DisplayName("옷 조회 성공 - hasNext = false")
-    void search_success() {
-        //given
-        int limit = 20;
+  @Test
+  @DisplayName("옷 조회 성공 - hasNext = false")
+  void search_success() {
+    //given
+    int limit = 20;
 
-        //when
-        Slice<Cloth> clothList = sut.searchCloths(null, null, limit, ClothType.SCARF,user.getId());
-        List<Cloth> content = clothList.getContent();
-        //then
-        assertThat(clothList.hasNext()).isFalse();
-        assertThat(content).hasSize(3);
-        assertThat(content.get(0)).isEqualTo(redScarf);
-        assertThat(content.get(1)).isEqualTo(whiteScarf);
-        assertThat(content.get(2)).isEqualTo(thinScarf);
-    }
+    //when
+    Slice<Cloth> clothList = sut.searchCloths(null, null, limit, ClothType.SCARF, user.getId());
+    List<Cloth> content = clothList.getContent();
+    //then
+    assertThat(clothList.hasNext()).isFalse();
+    assertThat(content).hasSize(3);
+    assertThat(content.get(0)).isEqualTo(redScarf);
+    assertThat(content.get(1)).isEqualTo(whiteScarf);
+    assertThat(content.get(2)).isEqualTo(thinScarf);
+  }
 
-    @Test
-    @DisplayName("옷 조회 성공 - hasNext=true")
-    void search_success_hasNext() {
-        //given
-        int limit = 2;
+  @Test
+  @DisplayName("옷 조회 성공 - hasNext=true")
+  void search_success_hasNext() {
+    //given
+    int limit = 2;
 
-        //when
-        Slice<Cloth> clothList = sut.searchCloths(null, null, limit, ClothType.SCARF,user.getId());
-        List<Cloth> content = clothList.getContent();
+    //when
+    Slice<Cloth> clothList = sut.searchCloths(null, null, limit, ClothType.SCARF, user.getId());
+    List<Cloth> content = clothList.getContent();
 
-        //then
-        assertThat(clothList.hasNext()).isTrue();
-        assertThat(content).hasSize(2);
-        assertThat(content.get(0)).isEqualTo(redScarf);
-        assertThat(content.get(1)).isEqualTo(whiteScarf);
-    }
+    //then
+    assertThat(clothList.hasNext()).isTrue();
+    assertThat(content).hasSize(2);
+    assertThat(content.get(0)).isEqualTo(redScarf);
+    assertThat(content.get(1)).isEqualTo(whiteScarf);
+  }
 
-    @Test
-    @DisplayName("속성 조회 성공 - 커서 존재")
-    void search_success_cursor() {
-        //given
-        int limit = 2;
-        Instant cursor = thinScarf.getCreatedAt();
+  @Test
+  @DisplayName("속성 조회 성공 - 커서 존재")
+  void search_success_cursor() {
+    //given
+    int limit = 2;
+    Instant cursor = thinScarf.getCreatedAt();
 
-        //when
-        Slice<Cloth> clothList = sut.searchCloths(cursor, null, limit, ClothType.SCARF,user.getId());
-        List<Cloth> content = clothList.getContent();
+    //when
+    Slice<Cloth> clothList = sut.searchCloths(cursor, null, limit, ClothType.SCARF, user.getId());
+    List<Cloth> content = clothList.getContent();
 
-        //then
-        assertThat(clothList.hasNext()).isTrue();
-        assertThat(content).hasSize(2);
-        assertThat(content.get(0)).isEqualTo(redScarf);
-        assertThat(content.get(1)).isEqualTo(whiteScarf);
-    }
+    //then
+    assertThat(clothList.hasNext()).isTrue();
+    assertThat(content).hasSize(2);
+    assertThat(content.get(0)).isEqualTo(redScarf);
+    assertThat(content.get(1)).isEqualTo(whiteScarf);
+  }
 
 }

--- a/src/test/java/com/codeit/weatherwear/domain/feed/repository/FeedRepositoryTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/repository/FeedRepositoryTest.java
@@ -76,10 +76,11 @@ class FeedRepositoryTest {
         .humidity(Humidity.builder().comparedToDayBefore(0.1).current(0.1).build())
         .location(location)
         .precipitation(
-            Precipitation.builder().amount(0).probability(0.1).type(PrecipitationsType.NONE)
+            Precipitation.builder().amount(0.0).probability(0.1).type(PrecipitationsType.NONE)
                 .build())
         .temperature(
-            Temperature.builder().comparedToDayBefore(10).current(23).max(30).min(20).build())
+            Temperature.builder().comparedToDayBefore(10.0).current(23.0).max(30.0).min(20.0)
+                .build())
         .skyStatus(SkyStatus.CLEAR)
         .windSpeed(WindSpeed.builder().speed(10).build())
         .build();


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#42 #113 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [x] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [x] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

refactor/113/refactor-weather -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

Weather 관련 리팩토링을 수행했습니다.
- Weather 및 Location 로직에 이해를 돕기 위한 주석 추가
- Weather 및 Location 로직에 예외 처리 추가
- SecurityConfig의 테스트 용으로 "/api/weather/**"부분 permitAll 해 뒀던 부분 삭제
- 날씨 세부 로직 리팩토링
  - Null 허용을 위해 double을 Double (wrapper 타입)으로 변경
  - 매직 넘버/매직 리터럴 수정

기존에 발견된 이슈들에 대해 수정하였습니다.
- 강수 확률 데이터 삽입 로직 수정
- 기존 날씨 데이터가 있음에도 재생성되는 오류 수정

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

![image](https://github.com/user-attachments/assets/0a4b676d-4664-4c5f-a0ef-cff22b1930f4)

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

### 🔊 추가 코멘트
`Null 허용을 위해 double을 Double (wrapper 타입)으로 변경` 과 관련하여 추가적으로 말씀드립니다.
해당 부분에서는 0.0 등으로 넣어두는 것이 원래 설계였습니다. 허나 리팩토링을 진행하며 생각이 바뀌어 이와 같이 변경하였음을 말씀드립니다.

기존에는 값이 없거나 누락된 경우에도 0.0 등의 숫자 값을 넣었습니다.
하지만 이렇게 하면 실제 값이 0인 경우(기온이 0도)와 데이터가 없는 경우(누락, 측정 불가 등)을 구분할 수 없습니다.
기온이 0도인 것과 기온 데이터가 없는 것은 완전히 다른 의미입니다.
이 둘을 모두 같은 값으로 표시하게 된다면, 데이터에 대한 잘못된 이해를 야기할 수 있다 판단했습니다.

따라서, 값이 없는 경우에는 0이 아니라 null(값 없음)로 처리하도록 변경했습니다.
이렇게 하면 실제 값과 데이터 부재를 정확히 구분할 수 있습니다.
이는 데이터의 신뢰성을 높이고, 우리가 의도한 대로 데이터가 해석될 수 있도록 유도할 수 있다고 판단했습니다.
이상입니다.
