### PR TITLE
Test: Feed 관련 기존 서비스 테스트 로직 수정

### DIFF
--- a/src/test/java/com/codeit/weatherwear/domain/feed/repository/impl/FeedCommentCustomRepositoryImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/repository/impl/FeedCommentCustomRepositoryImplTest.java
@@ -1,0 +1,139 @@
+package com.codeit.weatherwear.domain.feed.repository.impl;
+
+import static org.mockito.Mockito.mock;
+
+import com.codeit.weatherwear.domain.feed.dto.condition.FeedCommentSearchCondition;
+import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.feed.entity.FeedComment;
+import com.codeit.weatherwear.domain.location.entity.Location;
+import com.codeit.weatherwear.domain.user.entity.Gender;
+import com.codeit.weatherwear.domain.user.entity.Role;
+import com.codeit.weatherwear.domain.user.entity.User;
+import com.codeit.weatherwear.domain.weather.entity.Weather;
+import com.codeit.weatherwear.global.request.SortDirection;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class FeedCommentCustomRepositoryImplTest {
+
+  @InjectMocks
+  private FeedCommentCustomRepositoryImpl feedCommentCustomRepository;
+
+  @Mock
+  private JPAQueryFactory queryFactory;
+
+  private Feed feed;
+  private User author;
+  private List<FeedComment> feedComments;
+
+  @BeforeEach
+  void setUp() {
+    // Feed, User 더미 생성
+    UUID userId = UUID.randomUUID();
+    User author = createMockUser(userId, mock(Location.class));
+
+    UUID feedId = UUID.randomUUID();
+    Feed feed = createMockFeed(feedId, author, mock(Weather.class), "content");
+
+    // FeedComment 더미 리스트 생성 (limit + 1개)
+    int limit = 3;
+    List<FeedComment> commentList = new ArrayList<>();
+    for (int i = 0; i < limit + 1; i++) {
+      FeedComment comment = FeedComment.builder()
+          .feed(feed)
+          .author(author)
+          .content("댓글 내용 " + i)
+          .build();
+      ReflectionTestUtils.setField(comment, "id", UUID.randomUUID());
+      ReflectionTestUtils.setField(comment, "createdAt", Instant.now().plusSeconds(i));
+      commentList.add(comment);
+    }
+
+    // 테스트에서 사용하도록 필드에 저장
+    this.feed = feed;
+    this.author = author;
+    this.feedComments = commentList;
+  }
+
+  @Test
+  @DisplayName("성공적으로 페이지네이션이 적용된 피드 댓글을 반환한다")
+  void searchFeedComments_success() {
+    // given
+    int limit = 3;
+    UUID feedId = feed.getId();
+    UUID idAfter = feedComments.get(0).getId();
+    String cursor = feedComments.get(0).getCreatedAt().toString();
+
+    FeedCommentSearchCondition.builder()
+        .feedId(feedId)
+        .cursor(cursor)
+        .idAfter(idAfter)
+        .limit(limit)
+        .sortBy("createdAt")
+        .sortDirection(SortDirection.ASCENDING)
+        .build();
+
+    // QueryDSL JPAQuery mock 체이닝 ->
+    // Java의 제네릭 타입 소거로 인한 명시적 캐스팅 (해도 안해도 Unchecked assignment 발생)
+    JPAQuery<FeedComment> mockQuery = (JPAQuery<FeedComment>) mock(JPAQuery.class);
+
+//    given(queryFactory.selectFrom(any(QFeedComment.class))).willReturn(mockQuery);
+//    given(mockQuery.join((any(), any())).willReturn(mockQuery);
+//    given(mockQuery.fetchJoin()).willReturn(mockQuery);
+//    given(mockQuery.where(any(), any())).willReturn(mockQuery);
+//    given(mockQuery.orderBy(any(OrderSpecifier[].class))).willReturn(mockQuery);
+//    given(mockQuery.limit(anyLong())).willReturn(mockQuery);
+//    given(mockQuery.fetch()).willReturn(feedComments);
+
+    // when
+
+    // then
+  }
+
+  private User createMockUser(UUID userId, Location location) {
+    return User.builder()
+        .id(userId)
+        .email("test@example.com")
+        .name("홍길동")
+        .password("!password1234")
+        .role(Role.USER)
+        .locked(false)
+        .gender(Gender.FEMALE)
+        .birthDate(LocalDate.of(2000, 1, 1))
+        .temperatureSensitivity(10)
+        .profileImageUrl(null)
+        .location(location)
+        .createdAt(Instant.now())
+        .updatedAt(Instant.now())
+        .build();
+  }
+
+  private Feed createMockFeed(UUID feedId, User author, Weather weather, String content) {
+    Feed feed = Feed.builder()
+        .author(author)
+        .content(content)
+        .weather(weather)
+        .commentCount(0)
+        .likeCount(0)
+        .build();
+    ReflectionTestUtils.setField(feed, "id", feedId);
+    ReflectionTestUtils.setField(feed, "createdAt", Instant.now());
+    ReflectionTestUtils.setField(feed, "updatedAt", Instant.now());
+    return feed;
+  }
+
+}

--- a/src/test/java/com/codeit/weatherwear/domain/feed/repository/impl/FeedCustomRepositoryImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/repository/impl/FeedCustomRepositoryImplTest.java
@@ -1,0 +1,5 @@
+package com.codeit.weatherwear.domain.feed.repository.impl;
+
+class FeedCustomRepositoryImplTest {
+
+}

--- a/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImplTest.java
@@ -64,10 +64,6 @@ class FeedCommentServiceImplTest {
   @Mock
   private FeedCommentMapper feedCommentMapper;
 
-  private FeedCommentCreateRequest createRequest;
-  private FeedCommentGetParamRequest getParamRequest;
-  private FeedCommentSearchCondition condition;
-
   private Location mockLocation;
   private UUID authorId;
   private User author;

--- a/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImplTest.java
@@ -72,7 +72,6 @@ class FeedLikeServiceImplTest {
   private FeedLike feedLike;
 
   private User currentUser;
-  private UserSummaryDto currentUserDto;
 
   private List<OotdDto> ootds;
   private FeedDto feedDto;
@@ -98,8 +97,6 @@ class FeedLikeServiceImplTest {
         .createdAt(Instant.now())
         .updatedAt(Instant.now())
         .build();
-
-    currentUserDto = UserSummaryDto.from(currentUser);
 
     ootds = List.of(mock(OotdDto.class));
   }

--- a/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -49,7 +48,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,7 +57,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@Disabled
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class FeedServiceImplTest {
@@ -100,8 +97,6 @@ class FeedServiceImplTest {
   private FeedGetParamRequest mockFeedQuery;
 
   private WeatherSummaryDto mockWeatherDto;
-  private PrecipitationDto mockPrecipitation;
-  private TemperatureDto mockTemperature;
   private UserSummaryDto mockAuthorDto;
   private FeedDto mockFeedDto;
 
@@ -122,182 +117,73 @@ class FeedServiceImplTest {
 
   @BeforeEach
   void setUp() {
+    // 위치 정보
     mockLocation = new Location(37.513068, 127.102570, 961159, 1953082, "서울 송파구 신천동");
 
+    // 유저 정보
     authorId = UUID.randomUUID();
     currentUserId = authorId;
+    mockAuthor = createMockUser(authorId, mockLocation);
+    mockAuthorDto = UserSummaryDto.from(mockAuthor);
+
+    // 날씨 정보
     weatherId = UUID.randomUUID();
+    mockWeather = createMockWeather(weatherId, mockLocation);
+    mockWeatherDto = createMockWeatherDto(weatherId, mockWeather);
+
+    // 의류 정보
     clothId1 = UUID.randomUUID();
     clothId2 = UUID.randomUUID();
     clothIds = List.of(clothId1, clothId2);
+    mockOotdDto1 = createMockOotdDto(clothId1, "상의");
+    mockOotdDto2 = createMockOotdDto(clothId2, "하의");
 
-    mockContent = "Mock Feed Content";
+    // 피드 정보
+    feedId = UUID.randomUUID();
+    mockContent = "FeedContent - " + UUID.randomUUID();
+    mockFeed = createMockFeed(feedId, mockAuthor, mockWeather, mockContent);
+    mockFeedDto = createMockFeedDto(mockFeed, mockAuthorDto, mockWeatherDto,
+        List.of(mockOotdDto1, mockOotdDto2));
 
-    mockAuthor = User.builder()
-        .id(authorId)
-        .email("test@example.com")
-        .name("홍길동")
-        .password("!password1234")
-        .role(Role.USER)
-        .locked(false)
-        .gender(Gender.FEMALE)
-        .birthDate(LocalDate.of(2000, 1, 1))
-        .temperatureSensitivity(10)
-        .profileImageUrl(null)
-        .location(mockLocation)
-        .createdAt(Instant.now())
-        .updatedAt(Instant.now())
-        .build();
+    // 갱신 피드
+    updateContent = "update";
+    updateMockFeed = createMockFeed(feedId, mockAuthor, mockWeather, updateContent);
+    updateFeedDto = createMockFeedDto(updateMockFeed, mockAuthorDto, mockWeatherDto,
+        List.of(mockOotdDto1, mockOotdDto2));
 
-    mockAuthorDto = UserSummaryDto.from(mockAuthor);
-
+    // 요청/조건
     mockRequest = FeedCreateRequest.builder()
         .authorId(authorId)
         .weatherId(weatherId)
         .clothesIds(clothIds)
         .content(mockContent)
         .build();
-
-    mockWeather = Weather.builder()
-        .location(new Location(37.513068, 127.102570, 961159, 1953082, "서울 송파구 신천동"))
-        .forecastedAt(Instant.now()) // 예보 기준 시각
-        .forecastAt(Instant.now().plusSeconds(3600)) // 예보 시각 (예: 1시간 후)
-        .skyStatus(SkyStatus.CLEAR) // 예시: 맑음
-        .precipitation(
-            Precipitation.builder()
-                .type(PrecipitationsType.NONE)
-                .amount(0.0)
-                .probability(0.0)
-                .build()
-        )
-        .humidity(
-            Humidity.builder()
-                .current(50.0)
-                .comparedToDayBefore(0.0)
-                .build()
-        )
-        .temperature(
-            Temperature.builder()
-                .current(20.0)
-                .comparedToDayBefore(0.0)
-                .min(15.0)
-                .max(25.0)
-                .build()
-        )
-        .windSpeed(
-            WindSpeed.builder()
-                .speed(1.2)
-                .build()
-        )
-        .build();
-    ReflectionTestUtils.setField(mockWeather, "id", weatherId);
-
-    mockWeatherDto = WeatherSummaryDto.builder()
-        .weatherId(weatherId)
-        .skyStatus(SkyStatus.CLEAR)
-        .precipitation(mockPrecipitation)
-        .temperature(mockTemperature)
-        .build();
-
-    feedId = UUID.randomUUID();
-    mockFeed = Feed.builder()
-        .author(mockAuthor)
-        .content(mockContent)
-        .weather(mockWeather)
-        .commentCount(0)
-        .likeCount(0)
-        .build();
-    ReflectionTestUtils.setField(mockFeed, "id", feedId);
-
     mockFeedQuery = FeedGetParamRequest.builder()
         .limit(10)
         .sortBy("createdAt")
         .sortDirection("ASCENDING")
         .build();
-
     condition = mockFeedQuery.toSearchCondition();
-
-    mockPrecipitation = PrecipitationDto.builder()
-        .type(PrecipitationsType.NONE)
-        .amount(0.1)
-        .probability(0.1)
-        .build();
-
-    mockTemperature = TemperatureDto.builder()
-        .current(0.1)
-        .comparedToDayBefore(0.1)
-        .min(0.1)
-        .max(0.1)
-        .build();
-
-    mockOotdDto1 = OotdDto.builder()
-        .clothesId(clothId1)
-        .name("cloth1")
-        .imageUrl(null)
-        .type("상의")
-        .attributes(null)
-        .build();
-    mockOotdDto2 = OotdDto.builder()
-        .clothesId(clothId2)
-        .name("cloth2")
-        .imageUrl(null)
-        .type("하의")
-        .attributes(null)
-        .build();
-
-    mockFeedDto = FeedDto.builder()
-        .id(mockFeed.getId())
-        .createdAt(mockFeed.getCreatedAt())
-        .updatedAt(mockFeed.getUpdatedAt())
-        .author(mockAuthorDto)
-        .weather(mockWeatherDto)
-        .ootds(List.of(mockOotdDto1, mockOotdDto2))
-        .content(mockFeed.getContent())
-        .commentCount(mockFeed.getCommentCount())
-        .likeCount(mockFeed.getLikeCount())
-        .likedByMe(false)
-        .build();
-
-    updateContent = "수정된 메시지";
-    updateMockFeed = Feed.builder()
-        .author(mockAuthor)
-        .content(updateContent)
-        .weather(mockWeather)
-        .commentCount(0)
-        .likeCount(0)
-        .build();
-    ReflectionTestUtils.setField(updateMockFeed, "id", feedId);
-
-    updateFeedDto = FeedDto.builder()
-        .id(updateMockFeed.getId())
-        .createdAt(updateMockFeed.getCreatedAt())
-        .updatedAt(updateMockFeed.getUpdatedAt())
-        .author(mockAuthorDto)
-        .weather(mockWeatherDto)
-        .ootds(null)
-        .content(updateMockFeed.getContent())
-        .commentCount(updateMockFeed.getCommentCount())
-        .likeCount(updateMockFeed.getLikeCount())
-        .likedByMe(false)
-        .build();
-
-    ReflectionTestUtils.setField(mockFeed, "id", feedId);
   }
 
   @Test
   @DisplayName("Feed를 성공적으로 생성하여 FeedDto를 리턴합니다.")
   void createFeed_success() {
     // given
-    given(userRepository.findById(authorId)).willReturn(Optional.ofNullable(mockAuthor));
-    given(weatherRepository.findById(weatherId)).willReturn(Optional.ofNullable(mockWeather));
+    given(userRepository.findById(authorId)).willReturn(Optional.of(mockAuthor));
+    given(weatherRepository.findById(weatherId)).willReturn(Optional.of(mockWeather));
     given(feedMapper.toEntity(mockAuthor, mockWeather, mockRequest)).willReturn(mockFeed);
     given(feedRepository.save(mockFeed)).willReturn(mockFeed);
     given(ootdService.createOotdList(eq(mockFeed), eq(mockRequest.getClothesIds()))).willReturn(
         List.of(mockOotdDto1, mockOotdDto2));
     given(weatherMapper.toSummaryDto(eq(mockWeather))).willReturn(mockWeatherDto);
-    given(feedMapper.toDto(eq(mockFeed), eq(mockAuthorDto), any(WeatherSummaryDto.class),
+    given(feedMapper.toDto(
+        eq(mockFeed),
+        eq(mockAuthorDto),
+        eq(mockWeatherDto),
         eq(List.of(mockOotdDto1, mockOotdDto2)),
-        eq(false))).willReturn(mockFeedDto);
+        eq(false)
+    )).willReturn(mockFeedDto);
 
     // when
     FeedDto result = feedService.createFeed(mockRequest, currentUserId);
@@ -347,11 +233,12 @@ class FeedServiceImplTest {
     given(ootdService.findOotdByFeedId(eq(mockFeed.getId()))).willReturn(
         List.of(mockOotdDto1, mockOotdDto2));
     given(feedLikeService.isLikedByMe(mockFeed, currentUserId)).willReturn(false);
+    given(weatherMapper.toSummaryDto(eq(mockWeather))).willReturn(mockWeatherDto);
     given(feedMapper.toDto(
         eq(mockFeed),
         eq(mockAuthorDto),
-        any(WeatherSummaryDto.class),
-        anyList(),
+        eq(mockWeatherDto),
+        eq(List.of(mockOotdDto1, mockOotdDto2)),
         eq(false)
     )).willReturn(mockFeedDto);
 
@@ -381,12 +268,18 @@ class FeedServiceImplTest {
     FeedUpdateRequest updateRequest = FeedUpdateRequest.builder().content(updateContent).build();
 
     given(feedRepository.findById(feedId)).willReturn(Optional.of(mockFeed));
-    given(ootdService.findOotdByFeedId(eq(mockFeed.getId()))).willReturn(
+    mockFeed.updateContent(updateContent);
+    given(weatherMapper.toSummaryDto(eq(mockWeather))).willReturn(mockWeatherDto);
+    given(feedLikeService.isLikedByMe(eq(mockFeed), eq(currentUserId))).willReturn(false);
+    given(ootdService.findOotdByFeedId(mockFeed.getId())).willReturn(
         List.of(mockOotdDto1, mockOotdDto2));
-    given(feedLikeService.isLikedByMe(mockFeed, currentUserId)).willReturn(false);
-    given(feedMapper.toDto(eq(mockFeed), eq(mockAuthorDto), any(WeatherSummaryDto.class),
+    given(feedMapper.toDto(
+        eq(mockFeed),
+        eq(mockAuthorDto),
+        eq(mockWeatherDto),
         eq(List.of(mockOotdDto1, mockOotdDto2)),
-        eq(false))).willReturn(updateFeedDto);
+        eq(false)
+    )).willReturn(updateFeedDto);
 
     // when
     FeedDto result = feedService.updateFeed(feedId, updateRequest, currentUserId);
@@ -420,9 +313,14 @@ class FeedServiceImplTest {
     given(feedLikeService.isLikedByMe(mockFeed, currentUserId)).willReturn(false);
     given(ootdService.deleteOotdByFeedId(eq(mockFeed.getId()))).willReturn(
         List.of(mockOotdDto1, mockOotdDto2));
-    given(feedMapper.toDto(eq(mockFeed), eq(mockAuthorDto), any(WeatherSummaryDto.class),
+    given(weatherMapper.toSummaryDto(eq(mockWeather))).willReturn(mockWeatherDto);
+    given(feedMapper.toDto(
+        eq(mockFeed),
+        eq(mockAuthorDto),
+        eq(mockWeatherDto),
         eq(List.of(mockOotdDto1, mockOotdDto2)),
-        eq(false))).willReturn(mockFeedDto);
+        eq(false)
+    )).willReturn(mockFeedDto);
 
     // when
     FeedDto result = feedService.deleteFeed(feedId, currentUserId);
@@ -453,6 +351,129 @@ class FeedServiceImplTest {
     // when & then
     assertThatThrownBy(() -> feedService.deleteFeed(failedId, authorId))
         .isInstanceOf(FeedNotFoundException.class);
+  }
+
+  // Private Method
+
+  private User createMockUser(UUID userId, Location location) {
+    return User.builder()
+        .id(userId)
+        .email("test@example.com")
+        .name("홍길동")
+        .password("!password1234")
+        .role(Role.USER)
+        .locked(false)
+        .gender(Gender.FEMALE)
+        .birthDate(LocalDate.of(2000, 1, 1))
+        .temperatureSensitivity(10)
+        .profileImageUrl(null)
+        .location(location)
+        .createdAt(Instant.now())
+        .updatedAt(Instant.now())
+        .build();
+  }
+
+  private Weather createMockWeather(UUID weatherId, Location location) {
+    Weather weather = Weather.builder()
+        .location(location)
+        .forecastedAt(Instant.now())
+        .forecastAt(Instant.now().plusSeconds(3600))
+        .skyStatus(SkyStatus.CLEAR)
+        .precipitation(
+            Precipitation.builder()
+                .type(PrecipitationsType.NONE)
+                .amount(0.0)
+                .probability(0.0)
+                .build()
+        )
+        .humidity(
+            Humidity.builder()
+                .current(50.0)
+                .comparedToDayBefore(0.0)
+                .build()
+        )
+        .temperature(
+            Temperature.builder()
+                .current(20.0)
+                .comparedToDayBefore(0.0)
+                .min(15.0)
+                .max(25.0)
+                .build()
+        )
+        .windSpeed(
+            WindSpeed.builder()
+                .speed(1.2)
+                .build()
+        )
+        .build();
+    ReflectionTestUtils.setField(weather, "id", weatherId);
+    return weather;
+  }
+
+  private OotdDto createMockOotdDto(UUID clothesId, String type) {
+    return OotdDto.builder()
+        .clothesId(clothesId)
+        .name(type.equals("상의") ? "cloth1" : "cloth2")
+        .imageUrl(null)
+        .type(type)
+        .attributes(null)
+        .build();
+  }
+
+  private Feed createMockFeed(UUID feedId, User author, Weather weather, String content) {
+    Feed feed = Feed.builder()
+        .author(author)
+        .content(content)
+        .weather(weather)
+        .commentCount(0)
+        .likeCount(0)
+        .build();
+    ReflectionTestUtils.setField(feed, "id", feedId);
+    ReflectionTestUtils.setField(feed, "createdAt", Instant.now());
+    ReflectionTestUtils.setField(feed, "updatedAt", Instant.now());
+    return feed;
+  }
+
+  private FeedDto createMockFeedDto(Feed feed, UserSummaryDto authorDto,
+      WeatherSummaryDto weatherDto, List<OotdDto> ootds) {
+    return FeedDto.builder()
+        .id(feed.getId())
+        .createdAt(feed.getCreatedAt())
+        .updatedAt(feed.getUpdatedAt())
+        .author(authorDto)
+        .weather(weatherDto)
+        .ootds(ootds)
+        .content(feed.getContent())
+        .commentCount(feed.getCommentCount())
+        .likeCount(feed.getLikeCount())
+        .likedByMe(false)
+        .build();
+  }
+
+  private WeatherSummaryDto createMockWeatherDto(UUID weatherId, Weather mockWeather) {
+    return WeatherSummaryDto.builder()
+        .weatherId(weatherId)
+        .skyStatus(mockWeather.getSkyStatus())
+        .precipitation(createMockPrecipitationDto(mockWeather.getPrecipitation()))
+        .temperature(createMockTemperatureDto(mockWeather.getTemperature()))
+        .build();
+  }
+
+  private PrecipitationDto createMockPrecipitationDto(Precipitation precipitation) {
+    return PrecipitationDto.builder()
+        .type(precipitation.getType())
+        .amount(precipitation.getAmount())
+        .probability(precipitation.getProbability())
+        .build();
+  }
+
+  private TemperatureDto createMockTemperatureDto(Temperature temperature) {
+    return TemperatureDto.builder()
+        .current(temperature.getCurrent())
+        .comparedToDayBefore(temperature.getComparedToDayBefore())
+        .min(temperature.getMin())
+        .max(temperature.getMax())
+        .build();
   }
 
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#126

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

refactor/126/test-feeds -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

Feed 관련 기존 서비스 테스트 로직 수정
QueryDSL 부분 현재 작성 중에, 오전에 수정한 내용까지 PR 올리는 것이 좋을 것 같아 올립니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

기능 개발로 인해 수행되지 않아 @Disabled 해 두었던 FeedService 로직이 돌아갈 수 있도록 수정하였습니다.

![image](https://github.com/user-attachments/assets/02da8437-d532-41eb-b2d0-ba8603ddee9f)

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.