### PR TITLE
Test: User 도메인 테스트 코드 수정, 추가

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/user/controller/UserController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/controller/UserController.java
@@ -61,9 +61,9 @@ public class UserController {
   public ResponseEntity<ProfileDto> updateProfile(
       @PathVariable UUID userId,
       @Valid @RequestPart("request") ProfileUpdateRequest profileUpdateRequest,
-      @RequestPart(required = false) MultipartFile profileImage) {
+      @RequestPart(value = "image", required = false) MultipartFile profileImage) {
     // TODO: S3 세팅 후 프로필 이미지 업데이트 추가
-    ProfileDto result = userService.updateProfile(userId, profileUpdateRequest);
+    ProfileDto result = userService.updateProfile(userId, profileUpdateRequest, profileImage);
     return ResponseEntity.ok(result);
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/user/controller/UserController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/controller/UserController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -40,7 +41,7 @@ public class UserController {
   public ResponseEntity<UserDto> createUser(
       @Valid @RequestBody UserCreateRequest userCreateRequest) {
     UserDto result = userService.create(userCreateRequest);
-    return ResponseEntity.ok(result);
+    return ResponseEntity.status(HttpStatus.CREATED).body(result);
   }
 
   @GetMapping("/{userId}/profiles")
@@ -62,7 +63,6 @@ public class UserController {
       @PathVariable UUID userId,
       @Valid @RequestPart("request") ProfileUpdateRequest profileUpdateRequest,
       @RequestPart(value = "image", required = false) MultipartFile profileImage) {
-    // TODO: S3 세팅 후 프로필 이미지 업데이트 추가
     ProfileDto result = userService.updateProfile(userId, profileUpdateRequest, profileImage);
     return ResponseEntity.ok(result);
   }

--- a/src/main/java/com/codeit/weatherwear/domain/user/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/repository/UserCustomRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -22,87 +23,89 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class UserCustomRepositoryImpl implements UserCustomRepository {
 
-    private final JPAQueryFactory queryFactory;
+  private final JPAQueryFactory queryFactory;
 
-    @Override
-    public Slice<User> searchUsers(String cursor, UUID idAfter, int limit,
-        String sortBy, SortDirection sortDirection, String emailLike, Role roleEqual,
-        Boolean locked) {
+  @Override
+  public Slice<User> searchUsers(String cursor, UUID idAfter, int limit,
+      String sortBy, SortDirection sortDirection, String emailLike, Role roleEqual,
+      Boolean locked) {
 
-        QUser user = QUser.user;
+    QUser user = QUser.user;
 
-        // 정렬 방향
-        Order direction =
-            (sortDirection.equals(SortDirection.ASCENDING)) ? Order.ASC : Order.DESC;
-        OrderSpecifier<?> orderSpecifier;
+    // 정렬 방향
+    Order direction =
+        (sortDirection.equals(SortDirection.ASCENDING)) ? Order.ASC : Order.DESC;
+    List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
 
-        switch (sortBy) {
-            case "email":
-                orderSpecifier = new OrderSpecifier<>(direction, user.email);
-                break;
-            case "createdAt":
-                orderSpecifier = new OrderSpecifier<>(direction, user.createdAt);
-                break;
-            default:
-                throw new IllegalArgumentException("지원하지 않는 정렬 기준입니다.");
-        }
+    // 필터링 (이메일, 권한, 잠금상태)
+    BooleanBuilder where = new BooleanBuilder();
+    where.and((emailLike == null || emailLike.isBlank()) ? null :
+        user.email.containsIgnoreCase(emailLike));
+    where.and((roleEqual == null) ? null : user.role.eq(roleEqual));
+    where.and((locked == null) ? null : user.locked.eq(locked));
 
-        // 필터링 (이메일, 권한, 잠금상태)
-        BooleanBuilder where = new BooleanBuilder();
-        where.and((emailLike == null || emailLike.isBlank()) ? null :
-            user.email.containsIgnoreCase(emailLike));
-        where.and((roleEqual == null) ? null : user.role.eq(roleEqual));
-        where.and((locked == null) ? null : user.locked.eq(locked));
+    // 정렬 기준 + 커서 조건
+    if (sortBy.equals("email")) {
+      // email 정렬 + id ASC 정렬
+      orderSpecifiers.add(new OrderSpecifier<>(direction, user.email));
+      orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, user.id));
 
-        // 정렬 기준과 커서에 따른 필터링
-        if (cursor != null && !cursor.isBlank()) {
-            switch (sortBy) {
-                case "email":
-                    where.and((direction.equals(Order.ASC))
-                        ? user.email.gt(cursor)
-                        : user.email.lt(cursor));
-                    break;
-                case "createdAt":
-                    Instant cursorInstant = Instant.parse(cursor);
-                    where.and((direction.equals(Order.ASC))
-                        ? user.createdAt.gt(cursorInstant)
-                        .or(user.createdAt.eq(cursorInstant).and(user.id.gt(idAfter)))
-                        : user.createdAt.lt(cursorInstant)
-                            .or(user.createdAt.eq(cursorInstant).and(user.id.lt(idAfter))));
-                    break;
-                default:
-                    throw new IllegalArgumentException("지원하지 않는 정렬 기준입니다.");
-            }
-        }
+      if (cursor != null && !cursor.isBlank()) {
+        where.and(direction.equals(Order.ASC)
+            ? user.email.gt(cursor)
+            .or(user.email.eq(cursor).and(user.id.gt(idAfter)))
+            : user.email.lt(cursor)
+                .or(user.email.eq(cursor).and(user.id.lt(idAfter)))
+        );
+      }
 
-        // limit + 1개 조회
-        JPAQuery<User> query = queryFactory.selectFrom(user);
-        query.where(where);
-        query.orderBy(orderSpecifier);
-        query.limit(limit + 1);
-        List<User> users = query.fetch();
+    } else if (sortBy.equals("createdAt")) {
+      // createdAt 정렬 + id ASC 정렬
+      orderSpecifiers.add(new OrderSpecifier<>(direction, user.createdAt));
+      orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, user.id));
 
-        boolean hasNext = users.size() > limit;
-        if (hasNext) {
-            users.remove(users.size() - 1);
-        }
+      if (cursor != null && !cursor.isBlank()) {
+        Instant cursorInstant = Instant.parse(cursor);
+        where.and(direction.equals(Order.ASC)
+            ? user.createdAt.gt(cursorInstant)
+            .or(user.createdAt.eq(cursorInstant).and(user.id.gt(idAfter)))
+            : user.createdAt.lt(cursorInstant)
+                .or(user.createdAt.eq(cursorInstant).and(user.id.lt(idAfter)))
+        );
+      }
 
-        return new SliceImpl<>(users, PageRequest.of(0, limit), hasNext);
+    } else {
+      throw new IllegalArgumentException("지원하지 않는 정렬 기준입니다.");
     }
 
-    @Override
-    public Long getTotalCount(String emailLike, Role roleEqual, Boolean locked) {
-        QUser user = QUser.user;
-        // 필터링 (이메일, 권한, 잠금상태)
-        BooleanBuilder where = new BooleanBuilder();
-        where.and((emailLike == null || emailLike.isBlank()) ? null :
-            user.email.containsIgnoreCase(emailLike));
-        where.and((roleEqual == null) ? null : user.role.eq(roleEqual));
-        where.and((locked == null) ? null : user.locked.eq(locked));
+    // limit + 1개 조회
+    JPAQuery<User> query = queryFactory.selectFrom(user)
+        .where(where)
+        .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+        .limit(limit + 1);
+    List<User> users = query.fetch();
 
-        return queryFactory.select(user.count())
-            .from(user)
-            .where(where)
-            .fetchOne();
+    boolean hasNext = users.size() > limit;
+    if (hasNext) {
+      users.remove(users.size() - 1);
     }
+
+    return new SliceImpl<>(users, PageRequest.of(0, limit), hasNext);
+  }
+
+  @Override
+  public Long getTotalCount(String emailLike, Role roleEqual, Boolean locked) {
+    QUser user = QUser.user;
+    // 필터링 (이메일, 권한, 잠금상태)
+    BooleanBuilder where = new BooleanBuilder();
+    where.and((emailLike == null || emailLike.isBlank()) ? null :
+        user.email.containsIgnoreCase(emailLike));
+    where.and((roleEqual == null) ? null : user.role.eq(roleEqual));
+    where.and((locked == null) ? null : user.locked.eq(locked));
+
+    return queryFactory.select(user.count())
+        .from(user)
+        .where(where)
+        .fetchOne();
+  }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/user/service/UserService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/service/UserService.java
@@ -10,6 +10,7 @@ import com.codeit.weatherwear.domain.user.dto.response.ProfileDto;
 import com.codeit.weatherwear.domain.user.dto.response.UserDto;
 import com.codeit.weatherwear.global.response.PageResponse;
 import java.util.UUID;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
 
@@ -17,7 +18,8 @@ public interface UserService {
 
   ProfileDto findProfile(UUID userId);
 
-  ProfileDto updateProfile(UUID userId, ProfileUpdateRequest profileUpdateRequest);
+  ProfileDto updateProfile(UUID userId, ProfileUpdateRequest profileUpdateRequest,
+      MultipartFile profileImage);
 
   UUID updateLock(UUID userId, UserLockUpdateRequest userLockUpdateRequest);
 

--- a/src/main/java/com/codeit/weatherwear/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/service/UserServiceImpl.java
@@ -18,6 +18,7 @@ import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
 import com.codeit.weatherwear.domain.user.mapper.UserMapper;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
 import com.codeit.weatherwear.global.response.PageResponse;
+import com.codeit.weatherwear.global.storage.ThumbnailImageStorage;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +41,7 @@ public class UserServiceImpl implements UserService {
   private final PasswordEncoder passwordEncoder;
   private final LocationService locationService;
   private final JwtSessionService jwtSessionService;
+  private final ThumbnailImageStorage thumbnailImageStorage;
 
 
   @Transactional
@@ -72,7 +75,8 @@ public class UserServiceImpl implements UserService {
 
   @Transactional
   @Override
-  public ProfileDto updateProfile(UUID userId, ProfileUpdateRequest profileUpdateRequest) {
+  public ProfileDto updateProfile(UUID userId, ProfileUpdateRequest profileUpdateRequest,
+      MultipartFile profileImage) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new UserNotFoundException(userId));
 
@@ -83,7 +87,14 @@ public class UserServiceImpl implements UserService {
       location = locationService.findOrCreateLocation(locationDto);
     }
 
-    // TODO: S3 세팅 완료되면 ProfileImageUrl도 업데이트
+    // ProfileImageUrl 업로드
+    String profileImageUrl = null;
+    if (profileImage != null && !profileImage.isEmpty()) {
+      log.debug("[Start Uploading Profile Image On S3] - userId: {}", userId);
+      profileImageUrl = thumbnailImageStorage.get(thumbnailImageStorage.upload(profileImage));
+      log.debug("[Uploading Profile Image On S3 Completed] - userId: {}, url: {}", userId,
+          profileImageUrl);
+    }
 
     user.updateProfile(
         profileUpdateRequest.name(),
@@ -91,7 +102,7 @@ public class UserServiceImpl implements UserService {
         profileUpdateRequest.birthDate(),
         location,
         profileUpdateRequest.temperatureSensitivity(),
-        null);
+        profileImageUrl);
 
     return userMapper.toProfileDto(user);
   }

--- a/src/main/java/com/codeit/weatherwear/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/service/UserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.codeit.weatherwear.domain.user.service;
 
+import com.codeit.weatherwear.domain.event.DomainEventPublisher;
+import com.codeit.weatherwear.domain.event.dto.RoleChangedEvent;
 import com.codeit.weatherwear.domain.location.dto.LocationDto;
 import com.codeit.weatherwear.domain.location.entity.Location;
 import com.codeit.weatherwear.domain.location.service.LocationService;
@@ -12,6 +14,7 @@ import com.codeit.weatherwear.domain.user.dto.request.UserRoleUpdateRequest;
 import com.codeit.weatherwear.domain.user.dto.request.UserSearchRequest;
 import com.codeit.weatherwear.domain.user.dto.response.ProfileDto;
 import com.codeit.weatherwear.domain.user.dto.response.UserDto;
+import com.codeit.weatherwear.domain.user.entity.Role;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.exception.UserAlreadyExistsException;
 import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
@@ -42,6 +45,7 @@ public class UserServiceImpl implements UserService {
   private final LocationService locationService;
   private final JwtSessionService jwtSessionService;
   private final ThumbnailImageStorage thumbnailImageStorage;
+  private final DomainEventPublisher domainEventPublisher;
 
 
   @Transactional
@@ -139,10 +143,16 @@ public class UserServiceImpl implements UserService {
   public UserDto updateRole(UUID userId, UserRoleUpdateRequest userRoleUpdateRequest) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new UserNotFoundException(userId));
-    user.updateRole(userRoleUpdateRequest.role());
+    Role previousRole = user.getRole();
 
     // 권한 변경 시 해당 사용자는 자동으로 로그아웃
     jwtSessionService.invalidateToken(userId);
+
+    user.updateRole(userRoleUpdateRequest.role());
+
+    // 권한 변경 알림 전송
+    domainEventPublisher.publish(
+        new RoleChangedEvent(userId, userRoleUpdateRequest.role(), previousRole));
 
     return userMapper.toUserDto(user);
   }

--- a/src/test/java/com/codeit/weatherwear/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,330 @@
+package com.codeit.weatherwear.domain.user.controller;
+
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.codeit.weatherwear.domain.user.dto.request.ChangePasswordRequest;
+import com.codeit.weatherwear.domain.user.dto.request.ProfileUpdateRequest;
+import com.codeit.weatherwear.domain.user.dto.request.UserCreateRequest;
+import com.codeit.weatherwear.domain.user.dto.request.UserLockUpdateRequest;
+import com.codeit.weatherwear.domain.user.dto.request.UserRoleUpdateRequest;
+import com.codeit.weatherwear.domain.user.dto.response.ProfileDto;
+import com.codeit.weatherwear.domain.user.dto.response.UserDto;
+import com.codeit.weatherwear.domain.user.entity.Gender;
+import com.codeit.weatherwear.domain.user.entity.Role;
+import com.codeit.weatherwear.domain.user.entity.User;
+import com.codeit.weatherwear.domain.user.exception.UserAlreadyExistsException;
+import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
+import com.codeit.weatherwear.domain.user.service.UserService;
+import com.codeit.weatherwear.global.base.BaseControllerTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest extends BaseControllerTest {
+
+  @MockitoBean
+  private UserService userService;
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  UUID testUserId;
+  User testUser;
+  UserDto testUserDto;
+  ProfileDto testProfileDto;
+
+  @BeforeEach
+  void setUp() {
+    testUserId = UUID.randomUUID();
+    testUser = User.builder()
+        .id(testUserId)
+        .name("test")
+        .password("testpassword")
+        .email("test@test.com")
+        .locked(false)
+        .build();
+    testUserDto = new UserDto(testUser.getId(),
+        testUser.getCreatedAt(),
+        testUser.getEmail(),
+        testUser.getName(),
+        testUser.getRole(),
+        testUser.getLinkedOAuthProviders(),
+        testUser.isLocked());
+    testProfileDto = new ProfileDto(
+        testUser.getId(),
+        testUser.getName(),
+        testUser.getGender(),
+        testUser.getBirthDate(),
+        null,
+        testUser.getTemperatureSensitivity(),
+        testUser.getProfileImageUrl()
+    );
+  }
+
+  @Test
+  void 회원가입_성공() throws Exception {
+    // given
+    UserCreateRequest userCreateRequest = new UserCreateRequest("test", "test@test.com",
+        "testpassword");
+
+    given(userService.create(userCreateRequest)).willReturn(testUserDto);
+
+    // when & then
+    mockMvc.perform(
+            post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userCreateRequest))
+        )
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(testUserId.toString()))
+        .andExpect(jsonPath("$.name").value("test"));
+  }
+
+  @Test
+  void 회원가입_실패() throws Exception {
+    // given
+    UserCreateRequest userCreateRequest = new UserCreateRequest("test", "test@test.com",
+        "testpassword");
+
+    given(userService.create(userCreateRequest)).willThrow(new UserAlreadyExistsException());
+
+    // when & then
+    mockMvc.perform(
+            post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userCreateRequest))
+        )
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void 프로필_조회_성공() throws Exception {
+    // given
+    given(userService.findProfile(testUserId)).willReturn(testProfileDto);
+
+    // when & then
+
+    mockMvc.perform(
+            get("/api/users/{userId}/profiles", testUserId)
+        ).andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(testUserId.toString()))
+        .andExpect(jsonPath("$.name").value("test"));
+  }
+
+  @Test
+  void 프로필_조회_실패() throws Exception {
+    // given
+    given(userService.findProfile(testUserId)).willThrow(new UserNotFoundException(testUserId));
+
+    // when & then
+    mockMvc.perform(
+        get("/api/users/{userId}/profiles", testUserId)
+    ).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void 프로필_수정_성공() throws Exception {
+    // given
+    ProfileUpdateRequest request = new ProfileUpdateRequest(
+        "newName",
+        Gender.MALE,
+        LocalDate.now(),
+        null,
+        5
+    );
+
+    ProfileDto profileDto = new ProfileDto(
+        testUserId,
+        "newName",
+        Gender.MALE,
+        LocalDate.now(),
+        null,
+        5,
+        null
+    );
+
+    given(userService.updateProfile(testUserId, request, null)).willReturn(profileDto);
+
+    // when & then
+    MockMultipartFile requestPart = new MockMultipartFile(
+        "request",
+        "request.json",
+        MediaType.APPLICATION_JSON_VALUE,
+        objectMapper.writeValueAsBytes(request)
+    );
+
+    mockMvc.perform(multipart("/api/users/{userId}/profiles", testUserId)
+            .file(requestPart)
+            .with(rq -> {
+              rq.setMethod("PATCH");
+              return rq;
+            })
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(testUserId.toString()))
+        .andExpect(jsonPath("$.name").value("newName"));
+  }
+
+  @Test
+  void 프로필_수정_실패() throws Exception {
+    // given
+    ProfileUpdateRequest request = new ProfileUpdateRequest(
+        "newName",
+        Gender.MALE,
+        LocalDate.now(),
+        null,
+        5
+    );
+    given(userService.updateProfile(testUserId, request, null)).willThrow(
+        new UserNotFoundException(testUserId));
+
+    // when & then
+    MockMultipartFile requestPart = new MockMultipartFile(
+        "request",
+        "request.json",
+        MediaType.APPLICATION_JSON_VALUE,
+        objectMapper.writeValueAsBytes(request)
+    );
+
+    mockMvc.perform(multipart("/api/users/{userId}/profiles", testUserId)
+            .file(requestPart)
+            .with(rq -> {
+              rq.setMethod("PATCH");
+              return rq;
+            })
+        )
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void 잠금_상태_변경_성공() throws Exception {
+    // given
+    UserLockUpdateRequest userLockUpdateRequest = new UserLockUpdateRequest(true);
+    given(userService.updateLock(testUserId, userLockUpdateRequest)).willReturn(testUserId);
+
+    // when & then
+    mockMvc.perform(
+            patch("/api/users/{userId}/lock", testUserId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userLockUpdateRequest))
+        ).andExpect(status().isOk())
+        .andExpect(result -> result.equals(testUserId.toString()));
+  }
+
+  @Test
+  void 잠금_상태_변경_실패() throws Exception {
+    // given
+    UserLockUpdateRequest userLockUpdateRequest = new UserLockUpdateRequest(true);
+    given(userService.updateLock(testUserId, userLockUpdateRequest)).willThrow(
+        new UserNotFoundException(testUserId));
+
+    // when & then
+    mockMvc.perform(
+        patch("/api/users/{userId}/lock", testUserId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(userLockUpdateRequest))
+    ).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void 비밀번호_변경_성공() throws Exception {
+    // given
+    ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest("newPassword");
+    willDoNothing().given(userService).updatePassword(testUserId, changePasswordRequest);
+
+    // when & then
+    mockMvc.perform(
+        patch("/api/users/{userId}/password", testUserId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(changePasswordRequest))
+    ).andExpect(status().isOk());
+  }
+
+  @Test
+  void 비밀번호_변경_validation_실패() throws Exception {
+    // given
+    ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest("");
+    willDoNothing().given(userService).updatePassword(testUserId, changePasswordRequest);
+
+    // when & then
+    mockMvc.perform(
+        patch("/api/users/{userId}/password", testUserId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(changePasswordRequest))
+    ).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void 비밀번호_변경_사용자_검증_실패() throws Exception {
+    // given
+    ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest("newPassword");
+    willThrow(new UserNotFoundException(testUserId)).given(userService)
+        .updatePassword(testUserId, changePasswordRequest);
+
+    // when & then
+    mockMvc.perform(
+        patch("/api/users/{userId}/password", testUserId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(changePasswordRequest))
+    ).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void 권한_수정_성공() throws Exception {
+    // given
+    UserRoleUpdateRequest userRoleUpdateRequest = new UserRoleUpdateRequest(Role.ADMIN);
+
+    UserDto userDto = new UserDto(
+        testUser.getId(),
+        testUser.getCreatedAt(),
+        testUser.getEmail(),
+        testUser.getName(),
+        Role.ADMIN,
+        testUser.getLinkedOAuthProviders(),
+        testUser.isLocked()
+    );
+
+    given(userService.updateRole(testUserId, userRoleUpdateRequest)).willReturn(userDto);
+
+    // when & then
+    mockMvc.perform(
+            patch("/api/users/{userId}/role", testUserId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userRoleUpdateRequest))
+        ).andExpect(status().isOk())
+        .andExpect(jsonPath("$.role").value(Role.ADMIN.name()));
+  }
+
+  @Test
+  void 권한_수정_실패() throws Exception {
+    // given
+    UserRoleUpdateRequest userRoleUpdateRequest = new UserRoleUpdateRequest(Role.ADMIN);
+
+    given(userService.updateRole(testUserId, userRoleUpdateRequest)).willThrow(
+        new UserNotFoundException(testUserId));
+
+    // when & then
+    mockMvc.perform(
+        patch("/api/users/{userId}/role", testUserId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(userRoleUpdateRequest))
+    ).andExpect(status().isNotFound());
+  }
+
+}

--- a/src/test/java/com/codeit/weatherwear/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/user/repository/UserRepositoryTest.java
@@ -6,11 +6,11 @@ import com.codeit.weatherwear.domain.user.entity.Role;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.global.config.JpaConfig;
 import com.codeit.weatherwear.global.request.SortDirection;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@Slf4j
 @Import({JpaConfig.class})
 class UserRepositoryTest {
 
@@ -33,7 +34,7 @@ class UserRepositoryTest {
   private final List<User> testUsers = new ArrayList<>();
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws InterruptedException {
     testUsers.clear();
     for (int i = 1; i <= 5; i++) {
       User user = User.builder()
@@ -42,9 +43,9 @@ class UserRepositoryTest {
           .password("")
           .role(Role.USER)
           .locked(i % 2 == 0)
-          .createdAt(Instant.parse("2025-07-0" + i + "T00:00:00Z"))
           .build();
       testUsers.add(user);
+      Thread.sleep(1);
       em.persist(user);
     }
     em.flush();
@@ -122,24 +123,29 @@ class UserRepositoryTest {
         .containsExactly("user4@test.com", "user5@test.com");
   }
 
-  // todo: 해당 부분 테스트 실패로 주석 처리
-//  @Test
-//  void createdAt_커서페이징() {
-//    // given
-//    User user3 = userRepository.findByEmail("user3@test.com")
-//        .orElseThrow();
-//    // when
-//    Slice<User> result = userRepository.searchUsers(
-//        user3.getCreatedAt().toString(), user3.getId(), 2,
-//        "createdAt", SortDirection.ASCENDING, null, null, null
-//    );
-//
-//    // then
-//    assertThat(result.getContent()).hasSize(2);
-//    assertThat(result.getContent())
-//        .extracting(User::getEmail)
-//        .containsExactly("user4@test.com", "user5@test.com");
-//  }
+  @Test
+  void createdAt_커서페이징() {
+    // given
+    User user3 = userRepository.findByEmail("user3@test.com")
+        .orElseThrow();
+
+    for (User user : testUsers) {
+      log.info("name: " + user.getName() + " / " + user.getCreatedAt());
+    }
+    // when
+    Slice<User> result = userRepository.searchUsers(
+        user3.getCreatedAt().toString(), user3.getId(), 2,
+        "createdAt", SortDirection.ASCENDING, null, null, null
+    );
+    for (User user : result.getContent()) {
+      log.info("name: " + user.getName() + " / " + user.getCreatedAt());
+    }
+    // then
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.getContent())
+        .extracting(User::getEmail)
+        .containsExactly("user4@test.com", "user5@test.com");
+  }
 
   @Test
   void 조건에_맞는_유저_총_개수() {

--- a/src/test/java/com/codeit/weatherwear/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/user/service/UserServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.codeit.weatherwear.domain.event.DomainEventPublisher;
 import com.codeit.weatherwear.domain.location.service.LocationService;
 import com.codeit.weatherwear.domain.security.service.JwtSessionService;
 import com.codeit.weatherwear.domain.user.dto.request.ChangePasswordRequest;
@@ -58,6 +59,8 @@ class UserServiceImplTest {
   private LocationService locationService;
   @Mock
   private JwtSessionService jwtSessionService;
+  @Mock
+  private DomainEventPublisher domainEventPublisher;
 
 
   @Test

--- a/src/test/java/com/codeit/weatherwear/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/user/service/UserServiceImplTest.java
@@ -140,7 +140,7 @@ class UserServiceImplTest {
     when(userMapper.toProfileDto(user)).thenReturn(dto);
 
     // when
-    ProfileDto result = userService.updateProfile(userId, request);
+    ProfileDto result = userService.updateProfile(userId, request, null);
 
     // then
     assertThat(result.getName()).isEqualTo("newName");
@@ -161,7 +161,8 @@ class UserServiceImplTest {
     when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
     // when & then
-    assertThrows(UserNotFoundException.class, () -> userService.updateProfile(userId, request));
+    assertThrows(UserNotFoundException.class,
+        () -> userService.updateProfile(userId, request, null));
   }
 
   @Test


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev
refactor/129/profile-api ->dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- UserRepositoryTest에서 `createdAt_페이지네이션` 테스트 메서드가 랜덤하게 성공하기도, 실패하기도 했었는데 테스트 코드 문제가 아니라 UserRepository에서 정렬 기준이 제대로 적용되어있지 않았습니다...😩 수정했습니다.
  - 커서 기준으로 비교할 때 idAfter를 이용해 id도 함께 비교했으면서 막상 정렬 기준에는 id를 안 넣어서 생기는 문제였습니다.
- User 프로필 수정 시 프로필 이미지를 함께 업로드하는 로직을 추가했습니다.
- User 권한 수정 시 DomainEventPublisher를 통해 알림이 전송됩니다.
- UserController 테스트 코드를 추가했습니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
![image](https://github.com/user-attachments/assets/31081422-d50b-4578-9ed5-ded44df10de2)

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.
---

### 추가 코멘트

프로필 수정 API(/api/users/{userId}/profiles)에서
스웨거에 따르면 성공 시 status 200, 실패하면 status 400을 응답해야하는데요.

해당 API에서 실패할 일이 {userId}에 해당하는 유저가 존재하지 않는 경우 뿐이라
404 Not Found 응답을 보내도록 하였습니다.
다른 수정 API들에서도 실패 시 404 응답을 보내고, 그것이 의미적으로 맞다고 생각했습니다.

괜찮겠죠..?