### PR TITLE
Refactor: 이메일 전송 비동기, 템플릿 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,8 +117,10 @@ dependencies {
 
     //S3
     implementation 'software.amazon.awssdk:s3:2.31.7'
-}
 
+    // thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+}
 
 
 tasks.named('test') {

--- a/src/main/java/com/codeit/weatherwear/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/service/AuthServiceImpl.java
@@ -9,8 +9,6 @@ import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +20,7 @@ public class AuthServiceImpl implements AuthService {
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
-  private final JavaMailSender javaMailSender;
+  private final EmailService emailService;
   private final SecureRandom secureRandom = new SecureRandom();
   private final static String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345678";
 
@@ -42,7 +40,7 @@ public class AuthServiceImpl implements AuthService {
     String tempPassword = generateTempPassword();
 
     // 이메일 전송
-    sendTempPasswordEmail(email, tempPassword);
+    emailService.sendTempPasswordEmail(email, tempPassword);
 
     // DB 업데이트
     String encodedTempPassword = passwordEncoder.encode(tempPassword);
@@ -61,28 +59,5 @@ public class AuthServiceImpl implements AuthService {
     return stringBuffer.toString();
   }
 
-  private void sendTempPasswordEmail(String toEmail, String tempPassword) {
-    String content = """
-        안녕하세요.
-        "옷장을 부탁해" 서비스입니다.
-                
-        요청하신 임시 비밀번호는 아래와 같습니다.
-        --------------
-        %s
-        --------------
-                
-        임시 비밀번호는 발급 시점으로부터 10분 간 유효합니다.
-        로그인 후 반드시 비밀번호를 변경해주세요.
-                
-        감사합니다.        
-        """.formatted(tempPassword);
-
-    SimpleMailMessage message = new SimpleMailMessage();
-    message.setTo(toEmail);
-    message.setSubject("[옷장을 부탁해] 임시 비밀번호 안내");
-    message.setText(content);
-
-    javaMailSender.send(message);
-  }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/auth/service/EmailService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/service/EmailService.java
@@ -1,0 +1,7 @@
+package com.codeit.weatherwear.domain.auth.service;
+
+public interface EmailService {
+
+  void sendTempPasswordEmail(String toEmail, String tempPassword);
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/auth/service/EmailServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/service/EmailServiceImpl.java
@@ -1,0 +1,41 @@
+package com.codeit.weatherwear.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+  private final JavaMailSender javaMailSender;
+
+  @Async
+  public void sendTempPasswordEmail(String toEmail, String tempPassword) {
+    String content = """
+        안녕하세요.
+        "옷장을 부탁해" 서비스입니다.
+                
+        요청하신 임시 비밀번호는 아래와 같습니다.
+        --------------
+        %s
+        --------------
+                
+        임시 비밀번호는 발급 시점으로부터 10분 간 유효합니다.
+        로그인 후 반드시 비밀번호를 변경해주세요.
+                
+        감사합니다.        
+        """.formatted(tempPassword);
+
+    SimpleMailMessage message = new SimpleMailMessage();
+    message.setTo(toEmail);
+    message.setSubject("[옷장을 부탁해] 임시 비밀번호 안내");
+    message.setText(content);
+
+    javaMailSender.send(message);
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/auth/service/EmailServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/service/EmailServiceImpl.java
@@ -1,11 +1,15 @@
 package com.codeit.weatherwear.domain.auth.service;
 
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.mail.SimpleMailMessage;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 
 @Service
 @Slf4j
@@ -14,28 +18,30 @@ public class EmailServiceImpl implements EmailService {
 
   private final JavaMailSender javaMailSender;
 
+  private final TemplateEngine templateEngine;
+
+  @Value("${resetpassword.validity-seconds}")
+  private long passwordValiditySeconds;
+
   @Async
   public void sendTempPasswordEmail(String toEmail, String tempPassword) {
-    String content = """
-        안녕하세요.
-        "옷장을 부탁해" 서비스입니다.
-                
-        요청하신 임시 비밀번호는 아래와 같습니다.
-        --------------
-        %s
-        --------------
-                
-        임시 비밀번호는 발급 시점으로부터 10분 간 유효합니다.
-        로그인 후 반드시 비밀번호를 변경해주세요.
-                
-        감사합니다.        
-        """.formatted(tempPassword);
+    try {
+      // Thymeleaf context 설정
+      Context context = new Context();
+      context.setVariable("tempPassword", tempPassword);
+      context.setVariable("validMinutes", passwordValiditySeconds / 60);
 
-    SimpleMailMessage message = new SimpleMailMessage();
-    message.setTo(toEmail);
-    message.setSubject("[옷장을 부탁해] 임시 비밀번호 안내");
-    message.setText(content);
+      String htmlContent = templateEngine.process("email/reset-password", context);
 
-    javaMailSender.send(message);
+      MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+      MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "UTF-8");
+      helper.setTo(toEmail);
+      helper.setSubject("[옷장을 부탁해] 임시 비밀번호 안내");
+      helper.setText(htmlContent, true); // HTML 본문
+
+      javaMailSender.send(mimeMessage);
+    } catch (Exception e) {
+      log.error("임시 비밀번호 이메일 전송 실패", e);
+    }
   }
 }

--- a/src/main/resources/templates/email/reset-password.html
+++ b/src/main/resources/templates/email/reset-password.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<body
+    style="font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; line-height: 2.5; background-color: #ffffff; padding: 20px; color: #333;">
+<h2 style="text-align: left; color: #222; margin-bottom: 20px;">임시 비밀번호 안내</h2>
+<hr>
+
+<p style="margin-bottom: 16px; margin-top: 16px;">안녕하세요. <strong>옷장을 부탁해</strong> 서비스입니다.</p>
+
+<p style="margin-bottom: 16px;">요청하신 임시 비밀번호는 아래와 같습니다:</p>
+
+<div th:text="${tempPassword}"
+     style="
+       background-color: #e0f0ff;
+       border: 1px solid #cfe1fb;
+       color: #003399;
+       padding: 25px 40px;
+       border-radius: 12px;
+       font-size: 1.2em;
+       font-weight: 900;
+       text-align: left;
+       margin: 20px 0;
+       letter-spacing: 2px;
+       max-width: 300px;
+       min-width: 150px;
+     ">
+  TEMP_PASSWORD
+</div>
+
+<p style="margin-bottom: 16px;">이 임시 비밀번호는 <strong th:text="${validMinutes}">10분</strong>간 유효합니다.
+</p>
+<p style="margin-bottom: 16px;">로그인 후 <strong>반드시 비밀번호를 변경</strong>해주세요.</p>
+
+<div style="margin-top: 40px; font-size: 0.85em; color: #888; text-align: left;">
+  © 2025 옷장을 부탁해. All rights reserved.
+</div>
+
+<p></p>
+</body>


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#148 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

refactor/148/reset-password


### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- 비밀번호 초기화 요청 시 이메일 전송을 비동기로 수행하여 응답 시간을 개선했습니다. (평균 4-5s -> 평균 700-800ms)
- PlainText로만 보내던 이메일에 Thymeleaf로 템플릿을 적용하여 디자인을 개선해봤습니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.

---

### 추가 코멘트

원래는 시큐리티 리팩토링 작업과 테스트 작업을 계획하고 있었는데요
리팩토링 양이 생각보다 적어 테스트 코드와 함께 업로드하려고 PR을 미뤘습니다.

대신 auth 기능 중 비밀번호 초기화 API를 리팩토링한 PR을 올립니다.
변경 사항에 말한대로 응답 시간에서 가장 개선됐습니다.

이메일 before
<img width="547" height="479" alt="image" src="https://github.com/user-attachments/assets/05cf5acb-8584-4c3d-9d2c-c57c68e97698" />

이메일 after
<img width="681" height="653" alt="image" src="https://github.com/user-attachments/assets/026bc04f-f7c5-410e-9940-1c7b2210021b" />

사실 디자인 별 차이는 없지만.. SimpleMailMessage 인스턴스가 아니라 MimeMessage 인스턴스를 새롭게 알게 되서 좋은 경험이었습니다.

추가로 알게된 점이 있는데, 평소하던대로 `<style> ... </style>` 태그 내에서 css를 작성하면 네이버 메일의 경우 css를 무시하여
라인별로 `<p style="margin-bottom: 16px;">`와 같이 인라인으로 작성해줘야 했습니다.
