### PR TITLE
Test: sse 통합 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,8 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
+    testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // JPA Json 타입 매핑용

--- a/src/main/java/com/codeit/weatherwear/domain/event/listener/WebSocketHandler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/event/listener/WebSocketHandler.java
@@ -25,9 +25,9 @@ public class WebSocketHandler {
     String destination;
 
     if (receiverId.compareTo(senderId) < 0) {
-      destination = String.format("/sub/direct-message_%s_%s", receiverId, senderId);
+      destination = String.format("/sub/direct-messages_%s_%s", receiverId, senderId);
     } else {
-      destination = String.format("/sub/direct-message_%s_%s", senderId, receiverId);
+      destination = String.format("/sub/direct-messages_%s_%s", senderId, receiverId);
     }
     messagingTemplate.convertAndSend(destination, dto);
   }

--- a/src/main/java/com/codeit/weatherwear/global/sse/SseController.java
+++ b/src/main/java/com/codeit/weatherwear/global/sse/SseController.java
@@ -20,7 +20,7 @@ public class SseController {
   @GetMapping
   public SseEmitter connect(
       @AuthenticationPrincipal CustomUserDetails userDetails,
-      @RequestParam(value = "LastEventId",required = false)UUID lastEventId
+      @RequestParam(value = "LastEventId",required = false) UUID lastEventId
   ) {
     UUID userId = userDetails.getUserId();
     return sseService.connect(userId, lastEventId);

--- a/src/main/java/com/codeit/weatherwear/global/sse/SseEmitterRepository.java
+++ b/src/main/java/com/codeit/weatherwear/global/sse/SseEmitterRepository.java
@@ -35,6 +35,7 @@ public class SseEmitterRepository {
       sseEmitters.remove(sseEmitter);
       if (sseEmitters.isEmpty()) {
         data.remove(receiverId);
+        sseEmitter.complete();
       }
     }
   }

--- a/src/main/java/com/codeit/weatherwear/global/sse/SseService.java
+++ b/src/main/java/com/codeit/weatherwear/global/sse/SseService.java
@@ -55,7 +55,7 @@ public class SseService {
     }
 
     try {
-      sseEmitter.send("sse connected");
+      sseEmitter.send(SseEmitter.event().comment("keep-alive"));
     } catch (IOException e) {
       log.error("SSE 연결 실패. receiverId={}", receiverId, e);
       sseEmitter.completeWithError(e);

--- a/src/test/java/com/codeit/weatherwear/global/config/TestSecurityConfig.java
+++ b/src/test/java/com/codeit/weatherwear/global/config/TestSecurityConfig.java
@@ -1,5 +1,9 @@
 package com.codeit.weatherwear.global.config;
 
+import com.codeit.weatherwear.domain.security.customauthentication.CustomUserDetails;
+import com.codeit.weatherwear.domain.user.entity.Role;
+import java.time.Instant;
+import java.util.UUID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -9,12 +13,10 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -40,11 +42,21 @@ public class TestSecurityConfig {
   @Bean
   public UserDetailsService userDetailsService() {
     // 가짜 인증 객체 설정
-    UserDetails user = User.withUsername("user")
-        .password("password") // NoOpPasswordEncoder를 사용하므로 암호화하지 않고 사용
-        .roles("ADMIN") // 관리자 권한 -> 모든 테스트에서 인가 통과 가능
-        .build();
-    return new InMemoryUserDetailsManager(user);  // 메모리에 저장
+    UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    CustomUserDetails customUser = new CustomUserDetails(
+        userId,
+        "user",
+        "password",
+        Role.ADMIN,
+        false,
+        Instant.now().plusSeconds(100)
+    );
+    return username -> {
+      if (!customUser.getUsername().equals(username)) {
+        throw new UsernameNotFoundException(username);
+      }
+      return customUser;
+    };
   }
 
   // 인증을 수행할 AuthenticationManager 등록

--- a/src/test/java/com/codeit/weatherwear/global/sse/SseEmitterRepositoryTest.java
+++ b/src/test/java/com/codeit/weatherwear/global/sse/SseEmitterRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.codeit.weatherwear.global.sse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class SseEmitterRepositoryTest {
+
+  SseEmitterRepository sseEmitterRepository;
+
+  @BeforeEach
+  void setUp() {
+    sseEmitterRepository = new SseEmitterRepository();
+  }
+
+  @Test
+  void save() {
+    UUID receiverId = UUID.randomUUID();
+    SseEmitter sseEmitter = new SseEmitter(1000L);
+
+    assertThat(sseEmitterRepository.findByReceiverId(receiverId)).isEmpty();
+    sseEmitterRepository.save(receiverId, sseEmitter);
+
+    assertThat(sseEmitterRepository.findByReceiverId(receiverId))
+        .hasSize(1)
+        .first()
+        .isEqualTo(sseEmitter);
+  }
+
+  @Test
+  void delete() {
+    UUID receiverId = UUID.randomUUID();
+    SseEmitter sseEmitter = new SseEmitter(1000L);
+
+    sseEmitterRepository.save(receiverId, sseEmitter);
+    sseEmitterRepository.delete(receiverId, sseEmitter);
+
+    assertThat(sseEmitterRepository.findByReceiverId(receiverId)).isEmpty();
+  }
+
+}

--- a/src/test/java/com/codeit/weatherwear/global/sse/SseIntegrationTest.java
+++ b/src/test/java/com/codeit/weatherwear/global/sse/SseIntegrationTest.java
@@ -1,16 +1,15 @@
 package com.codeit.weatherwear.global.sse;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.codeit.weatherwear.domain.notification.Notification.Level;
 import com.codeit.weatherwear.domain.notification.NotificationDto;
-import com.codeit.weatherwear.global.config.JpaConfig;
-import com.codeit.weatherwear.global.config.TestSecurityConfig;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
@@ -22,7 +21,6 @@ import reactor.test.StepVerifier;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @AutoConfigureWebTestClient
-@Import({JpaConfig.class, TestSecurityConfig.class})
 class SseIntegrationTest {
 
   @Autowired
@@ -41,7 +39,7 @@ class SseIntegrationTest {
         .returnResult(new ParameterizedTypeReference<ServerSentEvent<NotificationDto>>() {})
         .getResponseBody();
 
-    UUID userId = UUID.randomUUID();
+    UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
     NotificationDto notificationDto = new NotificationDto(
         UUID.randomUUID(),
         Instant.now(),
@@ -51,10 +49,12 @@ class SseIntegrationTest {
         Level.INFO
     );
 
-    StepVerifier.create(responseBody)
+    StepVerifier.create(responseBody.filter(e -> e.data() != null))
         .then(() -> sseService.send(userId, notificationDto))
-        .expectNextMatches(e ->
-            e.event().equals("notifications") && e.data().equals(notificationDto))
+        .assertNext(e -> {
+          assertThat(e.event()).isEqualTo("notifications");
+          assertThat(e.data()).isEqualTo(notificationDto);
+        })
         .thenCancel()
         .verify();
   }

--- a/src/test/java/com/codeit/weatherwear/global/sse/SseIntegrationTest.java
+++ b/src/test/java/com/codeit/weatherwear/global/sse/SseIntegrationTest.java
@@ -1,0 +1,61 @@
+package com.codeit.weatherwear.global.sse;
+
+import com.codeit.weatherwear.domain.notification.Notification.Level;
+import com.codeit.weatherwear.domain.notification.NotificationDto;
+import com.codeit.weatherwear.global.config.JpaConfig;
+import com.codeit.weatherwear.global.config.TestSecurityConfig;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@AutoConfigureWebTestClient
+@Import({JpaConfig.class, TestSecurityConfig.class})
+class SseIntegrationTest {
+
+  @Autowired
+  WebTestClient webTestClient;
+  @Autowired
+  SseService sseService;
+
+  @Test
+  void sseConnect() {
+    Flux<ServerSentEvent<NotificationDto>> responseBody = webTestClient.get()
+        .uri("/api/sse")
+        .accept(MediaType.TEXT_EVENT_STREAM)
+        .headers(h -> h.setBasicAuth("user", "password"))
+        .exchange()
+        .expectStatus().isOk()
+        .returnResult(new ParameterizedTypeReference<ServerSentEvent<NotificationDto>>() {})
+        .getResponseBody();
+
+    UUID userId = UUID.randomUUID();
+    NotificationDto notificationDto = new NotificationDto(
+        UUID.randomUUID(),
+        Instant.now(),
+        userId,
+        "test event",
+        "test event content",
+        Level.INFO
+    );
+
+    StepVerifier.create(responseBody)
+        .then(() -> sseService.send(userId, notificationDto))
+        .expectNextMatches(e ->
+            e.event().equals("notifications") && e.data().equals(notificationDto))
+        .thenCancel()
+        .verify();
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,3 +34,13 @@ app:
     email: admin_test@mail.com
     name: admin
     password: admintest1!
+
+weatherwear:
+  storage:
+    type: s3
+    s3:
+      access-key: asd
+      secret-key: asd
+      region: ap-northeast-2
+      bucket: asd
+      presigned-url-expiration: 600


### PR DESCRIPTION
## #️⃣ 연관 이슈
- #136

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
feat/136/test-websocket-sse -> dev

### 📑 변경 사항
- sse 통합 테스트 작성
- SseEmitterRepository 테스트 코드 작성
- 통합 테스트 시, 인증 관련 문제 해결

통합 테스트 수행 시, 인증 정보가 null인 문제가 있었습니다. 코드 게시판에 정리해 두었으니 한번 읽어보시면 좋을거 같습니다.
[통합 테스트 시 CustomUserDetails가 null인 문제](https://www.notion.so/for-share-exception-21a97c15da08810eb0f2ef3c51610913?p=23097c15da0880f390dfc5561647adb3&pm=s)
.env.test에 SSE_TIMEOUT 변수를 추가했습니다. 공유 폴더에 업데이트 해놨으니 확인하시고 반영해주시면 감사하겠습니다.


### 🛠 테스트 결과
모든 테스트가 문제없이 수행됩니다.

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.