### PR TITLE
Fix: nginx 설정에 oauth 경로 추가 #161

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -34,6 +34,21 @@ server {
         proxy_buffering off;       # SSE 버퍼링 방지
     }
 
+    location ~ ^/(oauth2|login)/ {
+        proxy_pass http://backend;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 600s;
+        proxy_buffering off;
+    }
+
     # 웹소켓 및 SSE 프록시 (ex: /ws/ 또는 /api/sse)
     location /ws/ {
         proxy_pass http://backend;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,7 @@ spring:
 
 server:
   shutdown: graceful
+  forward-headers-strategy: framework
 
 weather:
   api-url: ${WEATHER_INFO_API_URL}


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#161 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

fix/161/nginx-oauth -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- 도커 환경에서 구글/카카오 소셜 로그인 기능이 동작하도록 수정


### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

구글 로그인 성공
<img width="1919" height="868" alt="image" src="https://github.com/user-attachments/assets/3ce2ea73-5122-4a87-b649-fabd677fa8c8" />


카카오 로그인 성공
<img width="1918" height="910" alt="image" src="https://github.com/user-attachments/assets/23600b00-bc86-4d3f-9195-3ceeeffd5e3f" />


### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

---

### 추가 코멘트

코드 게시판 [도커 nginx 환경에서 OAuth 로그인 실패 문제](https://www.notion.so/nginx-OAuth-23197c15da0880b58729c78c387a3cb3)에 관련 글을 작성했습니다.

이 글에서도 언급했듯이 `proxy_set_header X-Forwarded-Host $host:3000;` 설정으로 해야
로컬에서 도커 실행했을 때 [localhost:3000/login/oauth2/code/google](http://localhost:3000/login/oauth2/code/google%EC%9D%B4)으로 잘 리디렉션이 됩니다.
하지만 로컬에서 도커를 실행하는 건 테스트이고
실제로 중요한 건 AWS 배포 시에 잘 되는가 여부이므로
`proxy_set_header X-Forwarded-Host $host;`로 포트번호는 3000으로 명시하지 않는 상태로 PR을 올립니다.
