### PR TITLE
Feat: OAuth2 로그인 기능 수정

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/security/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
       JwtLogoutHandler jwtLogoutHandler,
       CustomOAuth2UserService customOAuth2UserService,
       @Qualifier("customOAuth2SuccessHandler") AuthenticationSuccessHandler customOAuth2SuccessHandler,
-      AuthenticationFailureHandler customAuthenticationFailureHandler)
+      @Qualifier("customOAuth2FailureHandler") AuthenticationFailureHandler customOAuth2FailureHandler)
       throws Exception {
 
     httpSecurity
@@ -65,7 +65,7 @@ public class SecurityConfig {
             .userInfoEndpoint(userInfo -> userInfo
                 .userService(customOAuth2UserService))
             .successHandler(customOAuth2SuccessHandler)
-            .failureHandler(customAuthenticationFailureHandler)
+            .failureHandler(customOAuth2FailureHandler)
         )
         .sessionManagement(session -> session
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
@@ -113,7 +113,7 @@ public class SecurityConfig {
   public CustomAuthenticationFilter customAuthenticationFilter(
       ObjectMapper objectMapper,
       @Qualifier("customAuthenticationSuccessHandler") AuthenticationSuccessHandler authenticationSuccessHandler,
-      AuthenticationFailureHandler authenticationFailureHandler,
+      @Qualifier("customAuthenticationFailureHandler") AuthenticationFailureHandler authenticationFailureHandler,
       AuthenticationManager authenticationManager) {
 
     CustomAuthenticationFilter filter = new CustomAuthenticationFilter(objectMapper);
@@ -135,6 +135,7 @@ public class SecurityConfig {
   }
 
   @Bean
+  @Qualifier("customAuthenticationFailureHandler")
   public AuthenticationFailureHandler customAuthenticationFailureHandler(
       ObjectMapper objectMapper) {
     return new CustomAuthenticationFailureHandler(objectMapper);

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2FailureHandler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2FailureHandler.java
@@ -1,0 +1,40 @@
+package com.codeit.weatherwear.domain.security.customauthentication.oauth2;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Qualifier("customOAuth2FailureHandler")
+public class CustomOAuth2FailureHandler implements
+    AuthenticationFailureHandler {
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) throws IOException, ServletException {
+    String errorMessage = "OAuth 로그인 실패";
+
+    if (exception instanceof OAuth2AuthenticationException) {
+      errorMessage = ((OAuth2AuthenticationException) exception)
+          .getError().getDescription();
+    }
+
+    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    response.setContentType("application/json");
+    response.getWriter().write("""
+        {
+          "status": 400,
+          "message": "%s"
+        }
+        """.formatted(errorMessage));
+  }
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2UserService.java
@@ -7,13 +7,17 @@ import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,9 +27,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   private final UserRepository userRepository;
 
   @Override
+  @Transactional
   public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
     OAuth2User oAuth2User = super.loadUser(userRequest);
     String provider = userRequest.getClientRegistration().getRegistrationId();  // google / kakao
+    OAuthProvider oauthProvider = OAuthProvider.valueOf(provider);
 
     String email = null;
     String name = null;
@@ -44,20 +50,43 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다: " + provider);
     }
 
-    User user = userRepository.findByEmail(email)
-        .orElse(null);
-    if (user == null) {
-      // 새로운 회원으로 추가
-      user = userRepository.save(User.builder()
+    Optional<User> optionalUser = userRepository.findByEmail(email);
+    if (optionalUser.isPresent()) {
+      User user = optionalUser.get();
+      // 기존 회원이 소셜 연동되어 있지 않다면 연동 정보 추가
+      user.addLinkedOAuthProvider(oauthProvider);
+      // 로그인 성공
+      return toCustomUserDetails(user);
+    }
+
+    // findByEmail을 했을 때 없다면 신규 가입
+    try {
+      User newUser = userRepository.save(User.builder()
           .name(name)
           .email(email)
           .password("")
-          .linkedOAuthProviders(List.of(OAuthProvider.valueOf(provider)))
+          .linkedOAuthProviders(List.of(oauthProvider))
           .role(Role.USER)
           .build());
+      userRepository.flush();
+
+      return toCustomUserDetails(newUser);
+
+    } catch (DataIntegrityViolationException e) {
+      // 예: name 중복 (DB unique 제약 위반) -> 연동 실패
+      throw new OAuth2AuthenticationException(
+          new OAuth2Error("INVALID_REQUEST", "이미 존재하는 사용자 정보입니다.", null));
     }
-    return new CustomUserDetails(user.getId()
-        , user.getEmail(), user.getPassword(), user.getRole(), user.isLocked(),
-        user.getTempPasswordExpirationTime());
+  }
+
+  private CustomUserDetails toCustomUserDetails(User user) {
+    return new CustomUserDetails(
+        user.getId(),
+        user.getEmail(),
+        user.getPassword(),
+        user.getRole(),
+        user.isLocked(),
+        user.getTempPasswordExpirationTime()
+    );
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/user/entity/User.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/entity/User.java
@@ -16,6 +16,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -159,6 +160,15 @@ public class User {
     if (password != null && !password.isBlank()) {
       this.password = password;
       this.tempPasswordExpirationTime = tempPasswordExpirationTime;
+    }
+  }
+
+  public void addLinkedOAuthProvider(OAuthProvider oAuthProvider) {
+    if (this.linkedOAuthProviders == null) {
+      this.linkedOAuthProviders = new ArrayList<>();
+    }
+    if (!this.linkedOAuthProviders.contains(oAuthProvider)) {
+      this.linkedOAuthProviders.add(oAuthProvider);
     }
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/repository/UserRepository.java
@@ -11,15 +11,17 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID>, UserCustomRepository {
 
-    boolean existsByName(String name);
+  boolean existsByName(String name);
 
-    boolean existsByEmail(String email);
+  boolean existsByEmail(String email);
 
-    Optional<User> findByEmail(String email);
+  Optional<User> findByEmail(String email);
 
-    @Query("SELECT u.id FROM User u")
-    List<UUID> findAllId();
+  @Query("SELECT u.id FROM User u")
+  List<UUID> findAllId();
 
-    @Query("SELECT u.id FROM User u WHERE u.id IN :ids")
-    List<UUID> findExistingIds(List<UUID> ids);
+  @Query("SELECT u.id FROM User u WHERE u.id IN :ids")
+  List<UUID> findExistingIds(List<UUID> ids);
+
+  Optional<User> findByEmailAndName(String email, String name);
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#107 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

feat/107/oauth -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- 소셜 로그인 기능을 수정했습니다.
- 실패 시 status 500으로 인한 Whitelabel Error Page 대신 회원가입 실패 때와 같은 status 400을 응답하도록 하였습니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.

---

### 💡 추가 코멘트

처음 OAuth2 소셜 로그인을 구현할 때는 다음과 같이 단순한 흐름으로 진행했습니다.

- 소셜 계정 연동 시 linkedOAuthProviders 컬럼에 해당 OAuthProvider를 추가하여 사용자 정보를 저장한다.
- 이미 같은 계정이 존재하면 해당 사용자를 인증하여 로그인 처리한다.

하지만, 상은 님께서 공유해주신 경험인데
카카오와 구글에서 동일한 닉네임이 중복되어 name의 고유 제약 조건 위반으로 소셜 연동이 실패하며 status 500으로  Whitelabel Error Page 같은 일반 사용자가 이해하기 어려운 응답이 나오는 문제가 있었습니다.

<img width="1919" height="624" alt="image" src="https://github.com/user-attachments/assets/aa104837-bf1f-4490-ab65-634c64a618d3" />

이에 소셜 계정 연동의 경우를 보다 세분화하여 다음과 같은 정책과 처리 방식을 적용했습니다.



**✅ 정책**
- 로그인 시 사용자의 식별 기준은 이메일(email)만 사용한다.
- 이름(name)은 단순 표시용이며, 로그인이나 식별에는 관여하지 않는다.
- linkedOAuthProviders는 OAuth로 연동된 공급자 목록이다.
- name과 email 모두 데이터베이스의 고유 제약 조건이 적용된다.
- 소셜 로그인은 회원가입과 로그인 겸용으로 동작한다.

**✅ 소셜 로그인 시도 시 경우의 수 및 처리 방식**
- 똑같은 email, name 모두 DB에 없는 경우: 소셜 로그인으로 신규 가입
  - 자동 회원가입, 로그인 성공
- 똑같은 email이 이미 DB에 있으나 provider 연동 정보가 있는 경우
  - DB에 저장된 name이 OAuth2User로 가져온 이름과 달라도 이미 연동된 사용자이므로 로그인 성공
- 똑같은 email이 이미 DB에 있으나 provider 연동 정보가 없는 경우
  - 기존 회원이지만 아직 해당 소셜 연동은 안 됨
  - linkedOAuthProviders에 추가 후 로그인 성공
  - name은 기존에 저장된 값으로 유지
- email은 없으나 name이 이미 DB에 있는 경우(신규 가입 시도였는데 이미 같은 name이 존재) 
  - DB 제약 위반 -> 400 Bad Request 응답


- 이메일과 이름 모두 데이터베이스에 없는 경우
  - 소셜 로그인으로 신규 회원 가입을 진행한다.
  - 회원가입 및 로그인 모두 성공 처리한다.
- 이메일이 데이터베이스에 이미 존재하며, 해당 소셜 공급자 연동 정보도 있는 경우
  - 저장된 이름과 OAuth2User로부터 받은 이름이 다르더라도 이미 연동된 사용자로 간주하여 로그인에 성공한다.
- 이메일이 데이터베이스에 존재하지만, 해당 소셜 공급자 연동 정보는 없는 경우
  - 기존 회원이나 아직 해당 소셜 계정과 연동되지 않은 상태다.
  - linkedOAuthProviders에 해당 공급자를 추가하고 로그인에 성공한다.
  - name은 기존에 저장된 값을 유지한다.
- 이메일은 없으나 이름이 이미 데이터베이스에 존재하는 경우 (신규 가입 시도)
  - 데이터베이스 고유 제약 조건 위반으로 간주하여, HTTP 400 Bad Request 응답을 반환한다.
<img width="440" height="168" alt="image" src="https://github.com/user-attachments/assets/482570e2-c856-4507-9380-af9f02346946" />


또한 이름 중복이 너무 많을수도 있는 것을 걱정하여
이름 대신 닉네임을 가져오는 것은 어떠냐는 이야기가 있었는데
애초에 구글에서는 name만, 카카오에서는 nickname만 가져올 수 있는 듯 해 그 부분은 원래 코드를 유지합니다.

400 BAD REQUEST 응답을 하는 경우 조금 더 예쁘게 보여지면 좋겠지만.. 이건 프론트의 영역 같습니다 ㅎㅎ;;