### PR TITLE
Docs: User, Auth 도메인 swagger api 문서화

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.codeit.weatherwear.domain.auth.controller;
 
+import com.codeit.weatherwear.domain.auth.controller.api.AuthApi;
 import com.codeit.weatherwear.domain.auth.dto.ResetPasswordRequest;
+import com.codeit.weatherwear.domain.auth.dto.SignInRequest;
 import com.codeit.weatherwear.domain.auth.service.AuthService;
 import com.codeit.weatherwear.domain.security.dto.TokenRotationResult;
 import com.codeit.weatherwear.domain.security.service.JwtSessionService;
@@ -23,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/api/auth")
-public class AuthController {
+public class AuthController implements AuthApi {
 
   private final AuthService authService;
   private final JwtSessionService jwtSessionService;
@@ -65,4 +67,13 @@ public class AuthController {
     return ResponseEntity.ok(csrfToken);
   }
 
+  @PostMapping("/sign-in")
+  public void signIn(SignInRequest signInRequest) {
+    throw new UnsupportedOperationException("Only for Documentation");
+  }
+
+  @PostMapping("/sign-out")
+  public void signOut() {
+    throw new UnsupportedOperationException("Only for Documentation");
+  }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/auth/controller/api/AuthApi.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/controller/api/AuthApi.java
@@ -1,0 +1,118 @@
+package com.codeit.weatherwear.domain.auth.controller.api;
+
+import com.codeit.weatherwear.domain.auth.dto.ResetPasswordRequest;
+import com.codeit.weatherwear.domain.auth.dto.SignInRequest;
+import com.codeit.weatherwear.global.response.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "인증 관리", description = "인증 관련 API")
+@RequestMapping("/api/auth")
+public interface AuthApi {
+
+  @Operation(summary = "액세스 토큰 조회", description = "쿠키(refresh_token)에 저장된 리프레시 토큰으로 엑세스 토큰을 조회합니다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "인증 정보 조회 성공",
+          content = @Content(schema = @Schema(implementation = String.class))),
+      @ApiResponse(
+          responseCode = "401",
+          description = "인증 정보 조회 실패",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  @GetMapping
+  ResponseEntity<String> getMe(@CookieValue(value = "refresh_token") Cookie refreshToken);
+
+  @Operation(summary = "토큰 재발급", description = "쿠키(refresh_token)에 저장된 리프레시 토큰으로 리프레시 토큰과 엑세스 토큰을 재발급합니다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "토큰 재발급 성공",
+          content = @Content(schema = @Schema(implementation = String.class))),
+      @ApiResponse(
+          responseCode = "401",
+          description = "토큰 재발급 실패",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  @PostMapping
+  ResponseEntity<String> rotateToken(
+      @CookieValue(value = "refresh_token") Cookie refreshToken, HttpServletResponse response);
+
+  @Operation(summary = "비밀번호 초기화", description = "임시 비밀번호로 초기화 후 이메일로 전송합니다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "비밀번호 초기화 성공",
+          content = @Content(schema = @Schema())),
+      @ApiResponse(
+          responseCode = "404",
+          description = "비밀번호 초기화 실패",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  @PostMapping
+  ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequest request);
+
+  @Operation(summary = "CSRF 토큰 조회", description = "CSRF 토큰을 조회합니다. 토큰은 쿠키(XSRF-TOKEN)에 저장됩니다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "CSRF 토큰 조회 성공",
+          content = @Content(schema = @Schema(implementation = CsrfToken.class))),
+      @ApiResponse(
+          responseCode = "401",
+          description = "CSRF 토큰 조회 실패",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  @GetMapping
+  ResponseEntity<CsrfToken> getCsrfToken(CsrfToken csrfToken);
+
+  @Operation(summary = "로그인", description = "이메일과 비밀번호를 입력하여 로그인합니다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "로그인 성공",
+          content = @Content(schema = @Schema(implementation = String.class))),
+      @ApiResponse(
+          responseCode = "401",
+          description = "로그인 실패",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  @PostMapping
+  void signIn(@RequestBody SignInRequest signInRequest);
+
+  @Operation(summary = "로그아웃", description = "로그아웃합니다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "로그아웃 성공",
+          content = @Content(schema = @Schema())),
+      @ApiResponse(
+          responseCode = "401",
+          description = "로그아웃 실패",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  @PostMapping
+  void signOut();
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/auth/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/dto/ResetPasswordRequest.java
@@ -1,7 +1,9 @@
 package com.codeit.weatherwear.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 
+@Schema(description = "비밀번호 초기화 요청 시 임시 비밀번호를 받는 이메일 주소 정보")
 public record ResetPasswordRequest(
     @Email
     String email

--- a/src/main/java/com/codeit/weatherwear/domain/user/controller/UserController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.codeit.weatherwear.domain.user.controller;
 
+import com.codeit.weatherwear.domain.user.controller.api.UserApi;
 import com.codeit.weatherwear.domain.user.dto.request.ChangePasswordRequest;
 import com.codeit.weatherwear.domain.user.dto.request.ProfileUpdateRequest;
 import com.codeit.weatherwear.domain.user.dto.request.UserCreateRequest;
@@ -33,7 +34,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/api/users")
-public class UserController {
+public class UserController implements UserApi {
 
   private final UserService userService;
 

--- a/src/main/java/com/codeit/weatherwear/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/controller/api/UserApi.java
@@ -1,0 +1,139 @@
+package com.codeit.weatherwear.domain.user.controller.api;
+
+import com.codeit.weatherwear.domain.user.dto.request.ChangePasswordRequest;
+import com.codeit.weatherwear.domain.user.dto.request.ProfileUpdateRequest;
+import com.codeit.weatherwear.domain.user.dto.request.UserCreateRequest;
+import com.codeit.weatherwear.domain.user.dto.request.UserLockUpdateRequest;
+import com.codeit.weatherwear.domain.user.dto.request.UserRoleUpdateRequest;
+import com.codeit.weatherwear.domain.user.dto.request.UserSearchRequest;
+import com.codeit.weatherwear.domain.user.dto.response.ProfileDto;
+import com.codeit.weatherwear.domain.user.dto.response.UserDto;
+import com.codeit.weatherwear.global.response.ErrorResponse;
+import com.codeit.weatherwear.global.response.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "프로필 관리", description = "프로필 관련 API")
+@RequestMapping("/api/users")
+public interface UserApi {
+
+  @Operation(summary = "사용자 등록(회원가입)", description = "새로운 사용자를 등록한다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "201",
+          description = "사용자 등록(회원가입) 성공",
+          content = @Content(schema = @Schema(implementation = UserDto.class))),
+      @ApiResponse(
+          responseCode = "400",
+          description = "사용자 등록(회원가입) 실패",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  @PostMapping
+  ResponseEntity<UserDto> createUser(@RequestBody UserCreateRequest userCreateRequest);
+
+  @Operation(summary = "프로필 조회", description = "특정 사용자의 프로필을 조회한다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "프로필 조회 성공",
+          content = @Content(schema = @Schema(implementation = ProfileDto.class))),
+      @ApiResponse(
+          responseCode = "404",
+          description = "프로필 조회 실패 (사용자 없음)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<ProfileDto> findProfile(@PathVariable UUID userId);
+
+  @Operation(summary = "계정 목록 조회", description = "사용자 목록을 조회한다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "계정 목록 조회 성공",
+          content = @Content(schema = @Schema(implementation = PageResponse.class))),
+      @ApiResponse(
+          responseCode = "400",
+          description = "계정 목록 조회 실패",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<PageResponse<UserDto>> searchUsers(
+      @ModelAttribute @Valid UserSearchRequest userSearchRequest);
+
+  @Operation(summary = "프로필 업데이트", description = "사용자의 프로필 정보와 프로필 이미지를 업데이트한다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "프로필 업데이트 성공",
+          content = @Content(schema = @Schema(implementation = ProfileDto.class))),
+      @ApiResponse(
+          responseCode = "404",
+          description = "프로필 업데이트 실패 (사용자 없음)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<ProfileDto> updateProfile(
+      @PathVariable UUID userId,
+      @Valid @RequestPart("request") ProfileUpdateRequest profileUpdateRequest,
+      @RequestPart(value = "image", required = false) MultipartFile profileImage);
+
+  @Operation(summary = "계정 잠금 상태 변경", description = "[어드민 기능] 사용자 계정을 잠그거나 잠금 해제한다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "계정 잠금 상태 변경 성공",
+          content = @Content(schema = @Schema(implementation = UUID.class))),
+      @ApiResponse(
+          responseCode = "404",
+          description = "계정 잠금 상태 변경 실패 (사용자 없음)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<UUID> updateLock(@PathVariable UUID userId,
+      @RequestBody UserLockUpdateRequest userLockUpdateRequest);
+
+  @Operation(summary = "비밀번호 변경", description = "비밀번호를 변경한다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "204",
+          description = "비밀번호 변경 성공",
+          content = @Content(schema = @Schema())),
+      @ApiResponse(
+          responseCode = "404",
+          description = "비밀번호 변경 실패 (사용자 없음)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<Void> updatePassword(@PathVariable UUID userId,
+      @Valid @RequestBody ChangePasswordRequest changePasswordRequest);
+
+  @Operation(summary = "권한 수정", description = "[어드민 기능] 사용자의 권한을 수정한다.")
+  @ApiResponses({
+      @ApiResponse(
+          responseCode = "200",
+          description = "권한 수정 성공",
+          content = @Content(schema = @Schema(implementation = UserDto.class))),
+      @ApiResponse(
+          responseCode = "404",
+          description = "권한 수정 실패 (사용자 없음)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  ResponseEntity<UserDto> updateRole(@PathVariable UUID userId,
+      @RequestBody UserRoleUpdateRequest userRoleUpdateRequest);
+}

--- a/src/main/java/com/codeit/weatherwear/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/controller/api/UserApi.java
@@ -19,7 +19,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,7 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/users")
 public interface UserApi {
 
-  @Operation(summary = "사용자 등록(회원가입)", description = "새로운 사용자를 등록한다.")
+  @Operation(summary = "사용자 등록(회원가입)", description = "새로운 사용자를 등록합니다.")
   @ApiResponses({
       @ApiResponse(
           responseCode = "201",
@@ -46,7 +48,7 @@ public interface UserApi {
   @PostMapping
   ResponseEntity<UserDto> createUser(@RequestBody UserCreateRequest userCreateRequest);
 
-  @Operation(summary = "프로필 조회", description = "특정 사용자의 프로필을 조회한다.")
+  @Operation(summary = "프로필 조회", description = "특정 사용자의 프로필을 조회합니다.")
   @ApiResponses({
       @ApiResponse(
           responseCode = "200",
@@ -58,9 +60,10 @@ public interface UserApi {
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       )
   })
+  @GetMapping
   ResponseEntity<ProfileDto> findProfile(@PathVariable UUID userId);
 
-  @Operation(summary = "계정 목록 조회", description = "사용자 목록을 조회한다.")
+  @Operation(summary = "계정 목록 조회", description = "사용자 목록을 조회합니다.")
   @ApiResponses({
       @ApiResponse(
           responseCode = "200",
@@ -72,10 +75,11 @@ public interface UserApi {
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       )
   })
+  @GetMapping
   ResponseEntity<PageResponse<UserDto>> searchUsers(
       @ModelAttribute @Valid UserSearchRequest userSearchRequest);
 
-  @Operation(summary = "프로필 업데이트", description = "사용자의 프로필 정보와 프로필 이미지를 업데이트한다.")
+  @Operation(summary = "프로필 업데이트", description = "사용자의 프로필 정보와 프로필 이미지를 업데이트합니다.")
   @ApiResponses({
       @ApiResponse(
           responseCode = "200",
@@ -87,12 +91,13 @@ public interface UserApi {
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       )
   })
+  @PatchMapping
   ResponseEntity<ProfileDto> updateProfile(
       @PathVariable UUID userId,
       @Valid @RequestPart("request") ProfileUpdateRequest profileUpdateRequest,
       @RequestPart(value = "image", required = false) MultipartFile profileImage);
 
-  @Operation(summary = "계정 잠금 상태 변경", description = "[어드민 기능] 사용자 계정을 잠그거나 잠금 해제한다.")
+  @Operation(summary = "계정 잠금 상태 변경", description = "[어드민 기능] 사용자 계정을 잠그거나 잠금 해제합니다.")
   @ApiResponses({
       @ApiResponse(
           responseCode = "200",
@@ -104,10 +109,11 @@ public interface UserApi {
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       )
   })
+  @PatchMapping
   ResponseEntity<UUID> updateLock(@PathVariable UUID userId,
       @RequestBody UserLockUpdateRequest userLockUpdateRequest);
 
-  @Operation(summary = "비밀번호 변경", description = "비밀번호를 변경한다.")
+  @Operation(summary = "비밀번호 변경", description = "비밀번호를 변경합니다.")
   @ApiResponses({
       @ApiResponse(
           responseCode = "204",
@@ -119,10 +125,11 @@ public interface UserApi {
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       )
   })
+  @PatchMapping
   ResponseEntity<Void> updatePassword(@PathVariable UUID userId,
       @Valid @RequestBody ChangePasswordRequest changePasswordRequest);
 
-  @Operation(summary = "권한 수정", description = "[어드민 기능] 사용자의 권한을 수정한다.")
+  @Operation(summary = "권한 수정", description = "[어드민 기능] 사용자의 권한을 수정합니다.")
   @ApiResponses({
       @ApiResponse(
           responseCode = "200",
@@ -134,6 +141,7 @@ public interface UserApi {
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))
       )
   })
+  @PatchMapping
   ResponseEntity<UserDto> updateRole(@PathVariable UUID userId,
       @RequestBody UserRoleUpdateRequest userRoleUpdateRequest);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/user/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/dto/request/ChangePasswordRequest.java
@@ -1,8 +1,10 @@
 package com.codeit.weatherwear.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "비밀번호 변경 정보")
 public record ChangePasswordRequest(
     @NotNull(message = "비밀번호는 null이어서는 안 됩니다.")
     @Size(min = 6, max = 15, message = "비밀번호는 6-15자 사이여야 합니다.")

--- a/src/main/java/com/codeit/weatherwear/domain/user/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/dto/request/ProfileUpdateRequest.java
@@ -2,11 +2,13 @@ package com.codeit.weatherwear.domain.user.dto.request;
 
 import com.codeit.weatherwear.domain.location.dto.LocationDto;
 import com.codeit.weatherwear.domain.user.entity.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
+@Schema(description = "프로필 업데이트 정보")
 public record ProfileUpdateRequest(
     @Size(min = 1, max = 20, message = "이름은 1-20자 사이여야 합니다.")
     String name,

--- a/src/main/java/com/codeit/weatherwear/domain/user/dto/request/UserCreateRequest.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/dto/request/UserCreateRequest.java
@@ -1,9 +1,11 @@
 package com.codeit.weatherwear.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "회원가입 정보")
 public record UserCreateRequest(
     @NotNull(message = "이름은 null이어서는 안 됩니다.")
     @Size(min = 1, max = 20, message = "이름은 1-20자 사이여야 합니다.")

--- a/src/main/java/com/codeit/weatherwear/domain/user/dto/request/UserLockUpdateRequest.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/dto/request/UserLockUpdateRequest.java
@@ -1,5 +1,8 @@
 package com.codeit.weatherwear.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "계정 잠금 상태 변경 정보")
 public record UserLockUpdateRequest(
     boolean locked
 ) {

--- a/src/main/java/com/codeit/weatherwear/domain/user/dto/request/UserRoleUpdateRequest.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/dto/request/UserRoleUpdateRequest.java
@@ -1,7 +1,9 @@
 package com.codeit.weatherwear.domain.user.dto.request;
 
 import com.codeit.weatherwear.domain.user.entity.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "권한 수정 정보")
 public record UserRoleUpdateRequest(
     Role role
 ) {

--- a/src/main/java/com/codeit/weatherwear/domain/user/dto/request/UserSearchRequest.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/dto/request/UserSearchRequest.java
@@ -2,28 +2,28 @@ package com.codeit.weatherwear.domain.user.dto.request;
 
 import com.codeit.weatherwear.domain.user.entity.Role;
 import com.codeit.weatherwear.global.request.SortDirection;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
+@Schema(description = "계정 목록 조회 조건")
 public record UserSearchRequest(
     String cursor,
     UUID idAfter,
-
     @NotNull
     @Min(1)
     @Max(100)
     int limit,
-
     @NotBlank
     String sortBy,
-
     @NotNull
+    @Schema(allowableValues = "ASCENDING, DESCENDING")
     SortDirection sortDirection,
-
     String emailLike,
+    @Schema(allowableValues = "USER, ADMIN")
     Role roleEqual,
     Boolean locked
 ) {

--- a/src/main/java/com/codeit/weatherwear/domain/user/dto/response/ProfileDto.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/dto/response/ProfileDto.java
@@ -2,6 +2,7 @@ package com.codeit.weatherwear.domain.user.dto.response;
 
 import com.codeit.weatherwear.domain.location.dto.LocationDto;
 import com.codeit.weatherwear.domain.user.entity.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -9,13 +10,14 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "사용자 프로필 정보")
 public class ProfileDto {
 
-    private final UUID userId;
-    private final String name;
-    private final Gender gender;
-    private final LocalDate birthDate;
-    private final LocationDto location;
-    private final Integer temperatureSensitivity;
-    private final String profileImageUrl;
+  private final UUID userId;
+  private final String name;
+  private final Gender gender;
+  private final LocalDate birthDate;
+  private final LocationDto location;
+  private final Integer temperatureSensitivity;
+  private final String profileImageUrl;
 }

--- a/src/main/java/com/codeit/weatherwear/domain/user/dto/response/UserDto.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/dto/response/UserDto.java
@@ -2,6 +2,7 @@ package com.codeit.weatherwear.domain.user.dto.response;
 
 import com.codeit.weatherwear.domain.user.entity.OAuthProvider;
 import com.codeit.weatherwear.domain.user.entity.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -10,14 +11,15 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "사용자 정보")
 public class UserDto {
 
-    private final UUID id;
-    private final Instant createdAt;
-    private final String email;
-    private final String name;
-    private final Role role;
-    private final List<OAuthProvider> linkedOAuthProviders;
-    private final boolean locked;
+  private final UUID id;
+  private final Instant createdAt;
+  private final String email;
+  private final String name;
+  private final Role role;
+  private final List<OAuthProvider> linkedOAuthProviders;
+  private final boolean locked;
 
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호
#190 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [x] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

chore/190/user-swagger -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- UserController, AuthController swagger-api 문서를 작성했습니다.

<img width="1640" height="470" alt="image" src="https://github.com/user-attachments/assets/6eff2735-ec09-4ba8-9bb8-85ec3c3fe37e" />


<img width="1630" height="532" alt="image" src="https://github.com/user-attachments/assets/0276e10b-f1b8-416a-a860-c9a780b1c88c" />


### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.

---

### 추가 코멘트

/api/auth/sign-in과 /api/auth/sign-out은
AuthController에 코드가 있는 게 아니라 SecurityFilterChain에서 관리하는 api라
swagger를 어떻게 작성할지 고민이 있었는데
AuthController에 dummy 메서드를 추가하는 방식으로 작성했습니다.

api 요청이 들어올 때 컨트롤러보다 필터 체인에 먼저 들어가므로 이때 로그인과 로그아웃을 하면
AuthController에서 두 api를 처리할 일이 없어 괜찮습니다.