### PR TITLE
Fix: 유저 프로필 조회 실패 수정 #200

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/mapper/UserMapper.java
@@ -13,6 +13,9 @@ public interface UserMapper {
   UserDto toUserDto(User user);
 
   @Mapping(source = "user.id", target = "userId")
+  ProfileDto toProfileDto(User user);
+
+  @Mapping(source = "user.id", target = "userId")
   @Mapping(source = "imageUrl", target = "profileImageUrl")
   ProfileDto toProfileDto(User user, String imageUrl);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/service/UserServiceImpl.java
@@ -74,7 +74,11 @@ public class UserServiceImpl implements UserService {
   public ProfileDto findProfile(UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new UserNotFoundException(userId));
-    return userMapper.toProfileDto(user, thumbnailImageStorage.get(user.getProfileImageUrl()));
+    if (user.getProfileImageUrl() != null) {
+      return userMapper.toProfileDto(user, thumbnailImageStorage.get(user.getProfileImageUrl()));
+    } else {
+      return userMapper.toProfileDto(user);
+    }
   }
 
   @Transactional
@@ -108,7 +112,11 @@ public class UserServiceImpl implements UserService {
         profileUpdateRequest.temperatureSensitivity(),
         profileImageUrl);
 
-    return userMapper.toProfileDto(user, thumbnailImageStorage.get(user.getProfileImageUrl()));
+    if (user.getProfileImageUrl() != null) {
+      return userMapper.toProfileDto(user, thumbnailImageStorage.get(user.getProfileImageUrl()));
+    } else {
+      return userMapper.toProfileDto(user);
+    }
   }
 
   @Transactional

--- a/src/test/java/com/codeit/weatherwear/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/user/service/UserServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -145,7 +144,7 @@ class UserServiceImplTest {
     );
 
     when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-    when(userMapper.toProfileDto(eq(user), isNull())).thenReturn(dto);
+    when(userMapper.toProfileDto(eq(user))).thenReturn(dto);
 
     // when
     ProfileDto result = userService.updateProfile(userId, request, null);
@@ -205,7 +204,7 @@ class UserServiceImplTest {
     ProfileDto dto = new ProfileDto(userId, "test", null, null, null, null, null);
 
     when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-    when(userMapper.toProfileDto(eq(user), isNull())).thenReturn(dto);
+    when(userMapper.toProfileDto(eq(user))).thenReturn(dto);
 
     // when
     ProfileDto result = userService.findProfile(userId);


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#200 
 
### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

fix/200/user-find-profile -> dev


### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

1. 처음에 유저 프로필 업데이트 시 데이터베이스에 키를 저장해야하는데 presigned url을 저장하여 시간이 지난 후 프로필 이미지를 조회할 수 없는 문제가 있었습니다. 이에 #189 에서 키를 저장하고, UserMapper에서 ProfileDto를 만들 때 presigned url을 함께 넣도록 수정했습니다.
2. 1번에서 프로필 사진이 있는 유저에 대해서만 다시 테스트를 진행하고 프로필 사진이 없는 유저에 대해서는 테스트를 진행하지 않아 알아차리지 못한 문제가 있습니다.
프로필 사진이 없는 유저는 해당 컬럼이 null인 상태라 storage class에 presigned url을 만들어달라고 요청하면 null로 서명을 생성할 수 없어 `S3PresignedException`이 발생하여 500 Interval Server Error로 응답을 하게 된 것이었습니다.
3. DTO 매핑 때 프로필 사진이 있는 유저와 없는 유저를 구분하여 처리했습니다.
4. 이에 맞춰 테스트 코드도 변경됐습니다.


### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

- 프로필 사진이 있는 유저인 경우
<img width="1919" height="859" alt="image" src="https://github.com/user-attachments/assets/8a6e60bb-4df4-493b-acc8-02759eaa3035" />


- 프로필 사진이 없는 유저인 경우
<img width="1689" height="836" alt="image" src="https://github.com/user-attachments/assets/9dd71562-2246-465f-9d97-2cfacb2266f1" />

두 경우 모두 200 OK 응답을 했습니다.


### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.

프로필 사진이 있는 유저에서 오류가 났으니 해결하고 그 유저만 확인해보자~ 생각했다가
프로필 사진이 없는 유저에서 다시 오류가 발생한 것을 눈치못챘네요...
테스트는 모든 케이스를 꼼꼼히 해야겠다 반성하게 됐습니다 😩