### PR TITLE
Feat: 특별한 날씨 변화에 따른 알림 이벤트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     //S3
-    implementation 'software.amazon.awssdk:s3:2.31.7'
+    implementation 'software.amazon.awssdk:s3:2.32.4'
 
     // thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImpl.java
@@ -15,6 +15,7 @@ import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.event.dto.NewFeedCommentEvent;
 import com.codeit.weatherwear.global.response.PageResponse;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +38,7 @@ public class FeedCommentServiceImpl implements FeedCommentService {
   private final UserRepository userRepository;
 
   private final FeedCommentMapper feedCommentMapper;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
   @Transactional
   @Override
@@ -53,6 +56,8 @@ public class FeedCommentServiceImpl implements FeedCommentService {
     UserSummaryDto userSummary = UserSummaryDto.from(saved.getAuthor());
     FeedCommentDto feedCommentDto = feedCommentMapper.toDto(saved, userSummary);
     log.info("Create feed comment complete: {}", feedCommentDto.getId());
+    applicationEventPublisher.publishEvent(new NewFeedCommentEvent(feed.getAuthor().getId(),
+        feedCommentDto.getAuthor().name(), feedCommentDto.getContent()));
     return feedCommentDto;
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImpl.java
@@ -15,10 +15,12 @@ import com.codeit.weatherwear.domain.ootd.service.OotdService;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.event.dto.FeedLikeEvent;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +37,7 @@ public class FeedLikeServiceImpl implements FeedLikeService {
 
   private final FeedMapper feedMapper;
   private final FeedLikeMapper feedLikeMapper;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
   @Transactional
   @Override
@@ -53,6 +56,8 @@ public class FeedLikeServiceImpl implements FeedLikeService {
     FeedDto feedDto = feedMapper.toDto(feed, userSummaryDto, null, ootds, true);
 
     log.info("Add Feed Like Success");
+    applicationEventPublisher.publishEvent(
+        new FeedLikeEvent(feed.getAuthor().getId(), user.getName(), feedDto.getContent()));
     return feedDto;
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/user/repository/UserRepository.java
@@ -1,11 +1,13 @@
 package com.codeit.weatherwear.domain.user.repository;
 
+import com.codeit.weatherwear.domain.location.entity.Location;
 import com.codeit.weatherwear.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -24,4 +26,7 @@ public interface UserRepository extends JpaRepository<User, UUID>, UserCustomRep
   List<UUID> findExistingIds(List<UUID> ids);
 
   Optional<User> findByEmailAndName(String email, String name);
+
+  @Query("SELECT DISTINCT u.id FROM User u WHERE u.location = :location")
+  List<UUID> findUserIdsByLocation(@Param("location") Location location);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherAlertAnalyzer.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherAlertAnalyzer.java
@@ -33,7 +33,7 @@ public class WeatherAlertAnalyzer {
 
   private boolean isTempGapAlert(Weather todayForecast) {
     Temperature temperature = todayForecast.getTemperature();
-    return (temperature.getMax() - temperature.getMin()) >= 10.0;
+    return temperature != null && (temperature.getMax() - temperature.getMin()) >= 10.0;
   }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherAlertAnalyzer.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherAlertAnalyzer.java
@@ -23,7 +23,7 @@ public class WeatherAlertAnalyzer {
       reasons.add(WeatherAlertReason.TEMP_GAP);
     }
 
-    return WeatherAlertResult.builder().alertNeeded(!reasons.isEmpty()).reason(reasons).build();
+    return WeatherAlertResult.builder().alertNeeded(!reasons.isEmpty()).reasons(reasons).build();
   }
 
   private boolean isRainAlert(Weather todayForecast) {

--- a/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherAlertAnalyzer.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherAlertAnalyzer.java
@@ -1,0 +1,39 @@
+package com.codeit.weatherwear.domain.weather.batch.task;
+
+import com.codeit.weatherwear.domain.weather.entity.Precipitation;
+import com.codeit.weatherwear.domain.weather.entity.PrecipitationsType;
+import com.codeit.weatherwear.domain.weather.entity.Temperature;
+import com.codeit.weatherwear.domain.weather.entity.Weather;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WeatherAlertAnalyzer {
+
+  public WeatherAlertResult analyze(Weather todayForecast) {
+    List<WeatherAlertReason> reasons = new ArrayList<>();
+    // 비 예보 여부 확인
+    if (isRainAlert(todayForecast)) {
+      reasons.add(WeatherAlertReason.RAIN);
+    }
+
+    // 일교차 확인
+    if (isTempGapAlert(todayForecast)) {
+      reasons.add(WeatherAlertReason.TEMP_GAP);
+    }
+
+    return WeatherAlertResult.builder().alertNeeded(!reasons.isEmpty()).reason(reasons).build();
+  }
+
+  private boolean isRainAlert(Weather todayForecast) {
+    Precipitation precipitation = todayForecast.getPrecipitation();
+    return precipitation != null && precipitation.getType() != PrecipitationsType.NONE;
+  }
+
+  private boolean isTempGapAlert(Weather todayForecast) {
+    Temperature temperature = todayForecast.getTemperature();
+    return (temperature.getMax() - temperature.getMin()) >= 10.0;
+  }
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherAlertReason.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherAlertReason.java
@@ -1,0 +1,14 @@
+package com.codeit.weatherwear.domain.weather.batch.task;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WeatherAlertReason {
+  RAIN("오늘은 비 예보가 있으니 주의하세요."),
+  SNOW("오늘은 눈 예보가 있으니 주의하세요."),
+  TEMP_GAP("오늘은 일교차가 크니 옷차림에 주의하세요.");
+
+  private final String cause;
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherAlertResult.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherAlertResult.java
@@ -1,0 +1,9 @@
+package com.codeit.weatherwear.domain.weather.batch.task;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record WeatherAlertResult(boolean alertNeeded, List<WeatherAlertReason> reasons) {
+
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherItemProcessor.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherItemProcessor.java
@@ -1,11 +1,19 @@
 package com.codeit.weatherwear.domain.weather.batch.task;
 
 import com.codeit.weatherwear.domain.location.entity.Location;
+import com.codeit.weatherwear.domain.user.repository.UserRepository;
 import com.codeit.weatherwear.domain.weather.entity.Weather;
 import com.codeit.weatherwear.domain.weather.service.WeatherFetchService;
+import com.codeit.weatherwear.global.event.dto.WeatherAlertEvent;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
@@ -19,18 +27,58 @@ import org.springframework.stereotype.Component;
 public class WeatherItemProcessor {
 
   private final WeatherFetchService weatherFetchService;
+  private final UserRepository userRepository;
+  private final ApplicationEventPublisher applicationEventPublisher;
+  private final WeatherAlertAnalyzer weatherAlertAnalyzer;
 
   /**
    * 각 Location에 대해 외부 API를 호출해 해당 위치의 날씨 정보를 가져옴
    * <p>
    * Reader에서 받은 Location → List<Weather>로 변환
+   * <p>
+   * "특별한 변화(비 예보/일교차 심함 등)"가 있다면 알림 이벤트를 발행
    *
    * @return ItemProcessor<Location, List < Weather>>
    */
   @Bean
   public ItemProcessor<Location, List<Weather>> locationWeatherProcessor() {
-    return location -> weatherFetchService.fetchWeather(
-        location.getLatitude(), location.getLongitude()
-    );
+    return location -> {
+      // 해당 위치의 날씨 예보 가져오기
+      List<Weather> forecastList = weatherFetchService.fetchWeather(
+          location.getLatitude(), location.getLongitude()
+      );
+
+      // 오늘 날씨 예보 가져오기
+      LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+      Optional<Weather> todayForecastOpt = forecastList.stream()
+          .filter(weather -> {
+            LocalDate forecastDate = weather.getForecastAt()
+                .atZone(ZoneId.of("Asia/Seoul"))
+                .toLocalDate();
+            return forecastDate.equals(today);
+          })
+          .findFirst();
+
+      // 오늘 날씨 예보가 존재하는지 확인
+      todayForecastOpt.ifPresent(todayForecast -> {
+        WeatherAlertResult alertResult = weatherAlertAnalyzer.analyze(todayForecastOpt.get());
+        // 특이 사항 알람이 필요한 지 확인
+        if (alertResult.alertNeeded()) {
+          List<UUID> receiverIds = userRepository.findUserIdsByLocation(location);
+          // 만약 보낼 사람이 없어도 이벤트 발행하지 않음
+          if (!receiverIds.isEmpty()) {
+            String combinedReason = alertResult.reasons().stream()
+                .map(WeatherAlertReason::getCause)
+                .collect(Collectors.joining(", "));
+            // 필요한 알람에 대해 이벤트 발행
+            applicationEventPublisher.publishEvent(
+                new WeatherAlertEvent(receiverIds, location.getName(),
+                    combinedReason));
+          }
+        }
+      });
+
+      return forecastList;
+    };
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherItemProcessor.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherItemProcessor.java
@@ -61,7 +61,7 @@ public class WeatherItemProcessor {
 
       // 오늘 날씨 예보가 존재하는지 확인
       todayForecastOpt.ifPresent(todayForecast -> {
-        WeatherAlertResult alertResult = weatherAlertAnalyzer.analyze(todayForecastOpt.get());
+        WeatherAlertResult alertResult = weatherAlertAnalyzer.analyze(todayForecast);
         // 특이 사항 알람이 필요한 지 확인
         if (alertResult.alertNeeded()) {
           List<UUID> receiverIds = userRepository.findUserIdsByLocation(location);

--- a/src/main/java/com/codeit/weatherwear/global/event/dto/DomainEvent.java
+++ b/src/main/java/com/codeit/weatherwear/global/event/dto/DomainEvent.java
@@ -9,4 +9,7 @@ public sealed interface DomainEvent
     NewFollowerEvent,
     RoleChangedEvent,
     MultipleNotificationCreatedEvent,
-    NotificationCreatedEvent { }
+    NotificationCreatedEvent,
+    WeatherAlertEvent {
+
+}

--- a/src/main/java/com/codeit/weatherwear/global/event/dto/WeatherAlertEvent.java
+++ b/src/main/java/com/codeit/weatherwear/global/event/dto/WeatherAlertEvent.java
@@ -1,0 +1,12 @@
+package com.codeit.weatherwear.global.event.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record WeatherAlertEvent(
+    List<UUID> receiverIds,
+    String address,
+    String content
+) implements DomainEvent {
+
+}

--- a/src/main/java/com/codeit/weatherwear/global/event/listener/NotificationEventListener.java
+++ b/src/main/java/com/codeit/weatherwear/global/event/listener/NotificationEventListener.java
@@ -134,7 +134,7 @@ public class NotificationEventListener {
   @Async("eventExecutor")
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleWeatherEvent(WeatherAlertEvent event) {
-    String title = String.format("오늘 %s의 날씨를 유의하세요.", event.address());
+    String title = String.format("%s의 날씨 특이사항 알림", event.address());
     String content = event.content();
 
     notificationService.create(

--- a/src/main/java/com/codeit/weatherwear/global/event/listener/NotificationEventListener.java
+++ b/src/main/java/com/codeit/weatherwear/global/event/listener/NotificationEventListener.java
@@ -10,6 +10,7 @@ import com.codeit.weatherwear.global.event.dto.FolloweeFeedPostedEvent;
 import com.codeit.weatherwear.global.event.dto.NewFeedCommentEvent;
 import com.codeit.weatherwear.global.event.dto.NewFollowerEvent;
 import com.codeit.weatherwear.global.event.dto.RoleChangedEvent;
+import com.codeit.weatherwear.global.event.dto.WeatherAlertEvent;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -119,10 +120,25 @@ public class NotificationEventListener {
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handlePermissionChangedEvent(RoleChangedEvent event) {
     String title = "권한이 변경되었어요.";
-    String content = String.format("%s -> %s", event.previousRoles().name(), event.newRoles().name());
+    String content = String.format("%s -> %s", event.previousRoles().name(),
+        event.newRoles().name());
 
     notificationService.create(
         event.receiverId(),
+        title,
+        content,
+        Level.INFO
+    );
+  }
+
+  @Async("eventExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleWeatherEvent(WeatherAlertEvent event) {
+    String title = String.format("오늘 %s의 날씨를 유의하세요.", event.address());
+    String content = event.content();
+
+    notificationService.create(
+        event.receiverIds(),
         title,
         content,
         Level.INFO

--- a/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -26,6 +27,7 @@ import com.codeit.weatherwear.domain.user.entity.Role;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.event.dto.NewFeedCommentEvent;
 import com.codeit.weatherwear.global.request.SortDirection;
 import com.codeit.weatherwear.global.response.PageResponse;
 import java.time.Instant;
@@ -41,6 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -63,6 +66,9 @@ class FeedCommentServiceImplTest {
 
   @Mock
   private FeedCommentMapper feedCommentMapper;
+
+  @Mock
+  private ApplicationEventPublisher applicationEventPublisher;
 
   private Location mockLocation;
   private UUID authorId;
@@ -192,6 +198,7 @@ class FeedCommentServiceImplTest {
     given(feedCommentMapper.toEntity(feed, author, request.getContent())).willReturn(comment1);
     given(feedCommentRepository.save(comment1)).willReturn(comment1);
     given(feedCommentMapper.toDto(comment1, authorDto)).willReturn(commentDto1);
+    willDoNothing().given(applicationEventPublisher).publishEvent(any(NewFeedCommentEvent.class));
 
     // when
     FeedCommentDto result = feedCommentService.createFeedComment(feedId, request);

--- a/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImplTest.java
@@ -28,6 +28,7 @@ import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
 import com.codeit.weatherwear.domain.weather.entity.Weather;
+import com.codeit.weatherwear.global.event.dto.FeedLikeEvent;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -64,6 +66,9 @@ class FeedLikeServiceImplTest {
   private FeedMapper feedMapper;
   @Mock
   private FeedLikeMapper feedLikeMapper;
+
+  @Mock
+  private ApplicationEventPublisher applicationEventPublisher;
 
   private UUID feedId;
   private UUID currentUserId;
@@ -103,6 +108,7 @@ class FeedLikeServiceImplTest {
     given(ootdService.findOotdByFeedId(feedId)).willReturn(ootds);
     given(feedMapper.toDto(any(Feed.class), any(UserSummaryDto.class), any(), anyList(),
         anyBoolean())).willReturn(feedDto);
+    willDoNothing().given(applicationEventPublisher).publishEvent(any(FeedLikeEvent.class));
 
     // when
     FeedDto result = feedLikeService.addFeedLike(feedId, currentUserId);


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#205 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

feat/205/add-weather-noti -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- ApacheHttpClient 오류로 인한 의존성 버전을 업데이트 했습니다.
- 특별한 날씨 변화 발생 시 사용자에게 알림을 보내는 기능을 추가했습니다.
- 피드 관련 알림 이벤트 발행하는 로직을 추가하였습니다. (피드 좋아요/댓글 등록 시 알림 전달)

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

전체 테스트 모두 통과하였습니다.

<img width="916" height="489" alt="image" src="https://github.com/user-attachments/assets/66053318-0f17-4c21-ae09-b04e858ab7e8" />

아래와 같이 알림이 잘 전달됩니다.

<img width="1048" height="474" alt="스크린샷 2025-07-22 170750" src="https://github.com/user-attachments/assets/e4fbd3f5-7548-4999-86d6-b61dcf289aae" />


### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

### 🔊 추가 코멘트
#### 의존성 버전 업데이트 관련
해당 부분은 아직 다 작성하지 않았지만, 저희 팀 노션의 코드 게시판을 참고해주시면 좋을 것 같습니다.
어떤 예외가 발생했는지에 대해서는 적어뒀으니 참고해주시면 되겠습니다.
추후, 원인에 대해 알아볼 예정입니다.

[S3 연동 시 ApacheHttpClient 의존성 문제](https://fortunate-tiger-b01.notion.site/S3-ApacheHttpClient-23897c15da0880208b55c9a68ad705d8?source=copy_link)

#### 특별한 날씨 변화 알림 관련
원재님이 알림 관련 로직를 너무 잘 설계해주셔서 수월하게 작성할 수 있었네요! 감사합니다 😉

본론으로 들어가, 요구사항 중 특별한 날씨 변화 알림이 있어 해당 부분을 어떻게 설계할 지 부터 생각을 해 보았습니다.

1. 우선, 특별한 날씨 변화에 대해서 생각을 해 보았는데요,
사용자가 알면 좋겠다, 주의해서 옷을 입었으면 좋겠다 싶은 부분에 대해서 생각해 보았습니다.
- 당일 비 예보가 존재 (비가 올 수 있음)
- 일교차가 심할 때 (일반적으로 10도 이상이면 심한 것으로 고려한다고 합니다. 20도면 극심한 것이라고 해요)
- 이전과 비교하여 기온/습도 변화가 심할 때

일단은 이 정도로 생각을 했는데, 이전과 비교하는 부분은 조금 생각해야 할 부분이 있어서(로직 고쳐야 할 부분이 꽤 있을 것 같다는 뜻) 비교적 간단한 위의 2가지에 대해 구현하기로 하였습니다.

2. 언제 이벤트를 발생시켜야 하는 지에 대한 고민
우선, 날씨 예보를 조회하는 상황은 정기적인 배치 시간, 사용자가 위치를 변경하였을 때, 총 2가지입니다.
그런데 사용자가 직접 위치를 변경했을 때 이벤트를 발생시키게 된다면 사용자 경험으로도 좋지 않을 것이라 생각했습니다.
지역을 계속 이동하는 상황이라고 했을 때, 계속 알림이 오기 때문에 사용자 입장에서 귀찮고 번거로울 것이라고 생각했습니다.
또한, 이에 대한 중복 처리 관련 아이디어가 생각나지 않았습니다. ㅎㅎ
따라서,  배치가 수행될 때(정기 예보 조회 상황)만 발생시킨다면, 하루에 한 번만 발생하기에 중복 문제 또한 크게 고려되지 않는다고 판단하여, 우선 배치 상황에서 알림을 보내는 것으로 정했습니다.

전반적인 로직은,
> 날씨 예보를 성공적으로 잘 가져온 상태에서,
> 각 위치 별로 특별한 알림을 보내야 할 필요성이 있다 판단했을 때,
> 해당 위치를 연관 관계로 가지고 있는 사용자들의 id (receiverId)로 알림을 전송하는 것

이라고 알아주시면 될 것 같습니다.

3. 이벤트 알림 메시지 관련
실제 강제로 배치를 돌려 확인했을 때, 알림이 잘 오긴 하는데, 사진처럼 내용이 길면 끊기고 해서 이 부분은 조금 더 고민을 해 보고 수정 할 예정이라는 점 말씀드립니다.

4. WeatherAlert 관련 코드 패키지 위치 관련
요건 일단, 현재 상으로는 배치 로직에 들어가 있어서 일단 task에 넣어 두긴 했는데요,
batch 패키지 하위에 alert 패키지를 따로 만들어서 넣을지 고민중이긴 합니다.
추후 날씨 관련 알림 등을 배치가 아닌 실시간 상황에서도 보내게 된다면 weather 패키지 아래에 alert 패키지를 만들어 넣는 것이 좋다고 생각하기는 합니다. (하지만 지금은 아니라...)
 혹시 좋은 의견 있으시면 언제든 말해주세요!

이만, 총총.