### PR TITLE
Fix: 유저, 프로필 API 버그 리포트

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/auth/controller/AuthController.java
@@ -2,8 +2,8 @@ package com.codeit.weatherwear.domain.auth.controller;
 
 import com.codeit.weatherwear.domain.auth.controller.api.AuthApi;
 import com.codeit.weatherwear.domain.auth.dto.ResetPasswordRequest;
-import com.codeit.weatherwear.domain.security.dto.SignInRequest;
 import com.codeit.weatherwear.domain.auth.service.AuthService;
+import com.codeit.weatherwear.domain.security.dto.SignInRequest;
 import com.codeit.weatherwear.domain.security.dto.TokenRotationResult;
 import com.codeit.weatherwear.domain.security.service.JwtSessionService;
 import jakarta.servlet.http.Cookie;

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/CustomUserDetails.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/CustomUserDetails.java
@@ -60,7 +60,7 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
   @Override
   public boolean isCredentialsNonExpired() {
     if (tempPasswordExpirationTime != null && tempPasswordExpirationTime.isBefore(Instant.now())) {
-      log.info("만료된 임시 비밀번호");
+      log.info("Sign In Failed: Expired tempPassword");
       return false;
     }
     return true;

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.codeit.weatherwear.domain.security.customauthentication.jwt;
 
+import com.codeit.weatherwear.domain.security.SecurityRequestMatcher;
 import com.codeit.weatherwear.domain.security.customauthentication.CustomUserDetails;
 import com.codeit.weatherwear.domain.security.service.JwtSessionService;
 import com.codeit.weatherwear.domain.user.entity.User;
@@ -11,6 +12,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -89,4 +91,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     return null;
   }
 
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return Arrays.stream(SecurityRequestMatcher.PUBLIC_MATCHERS)
+        .anyMatch(matcher -> matcher.matches(request));
+  }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2FailureHandler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2FailureHandler.java
@@ -40,7 +40,7 @@ public class CustomOAuth2FailureHandler implements
       }
     }
 
-    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    response.setStatus(status);
     response.setContentType("application/json");
     response.getWriter().write("""
         {

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2FailureHandler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2FailureHandler.java
@@ -5,14 +5,17 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
+@Slf4j
 @Qualifier("customOAuth2FailureHandler")
 public class CustomOAuth2FailureHandler implements
     AuthenticationFailureHandler {
@@ -21,20 +24,30 @@ public class CustomOAuth2FailureHandler implements
   public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
       AuthenticationException exception) throws IOException, ServletException {
     String errorMessage = "OAuth 로그인 실패";
+    int status = HttpServletResponse.SC_UNAUTHORIZED;
 
-    if (exception instanceof OAuth2AuthenticationException) {
-      errorMessage = ((OAuth2AuthenticationException) exception)
-          .getError().getDescription();
+    if (exception instanceof OAuth2AuthenticationException oauthEx) {
+      OAuth2Error error = oauthEx.getError();
+      errorMessage = error.getDescription();
+
+      switch (error.getErrorCode()) {
+        case "ACCOUNT_LOCKED" -> status = HttpServletResponse.SC_UNAUTHORIZED; // 잠금 계정이면 401
+        case "USER_ALREADY_EXISTS" -> status = HttpServletResponse.SC_BAD_REQUEST; // 사용자 중복이면 400
+        default -> {
+          status = HttpServletResponse.SC_BAD_REQUEST;
+          log.warn("Undefined OAuth2 SignIn ErrorCode: {}", error.getErrorCode());
+        }
+      }
     }
 
     response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
     response.setContentType("application/json");
     response.getWriter().write("""
         {
-          "status": 400,
+          "status": %d,
           "message": "%s"
         }
-        """.formatted(errorMessage));
+        """.formatted(status, errorMessage));
   }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2UserService.java
@@ -5,6 +5,7 @@ import com.codeit.weatherwear.domain.user.entity.OAuthProvider;
 import com.codeit.weatherwear.domain.user.entity.Role;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.exception.ErrorCode;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -71,9 +72,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     Optional<User> optionalUser = userRepository.findByEmail(email);
     if (optionalUser.isPresent()) {
       User user = optionalUser.get();
+      // 계정이 잠금 상태면 로그인 불가능
+      if (user.isLocked()) {
+        log.info("소셜 로그인 - 잠금 계정");
+        throw new OAuth2AuthenticationException(
+            new OAuth2Error(ErrorCode.ACCOUNT_LOCKED.name(), ErrorCode.ACCOUNT_LOCKED.getMessage(),
+                null));
+      }
       // 기존 회원이 소셜 연동되어 있지 않다면 연동 정보 추가
       user.addLinkedOAuthProvider(oauthProvider);
-      // 로그인 성공
       return toCustomUserDetails(user);
     }
 
@@ -93,8 +100,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     } catch (DataIntegrityViolationException e) {
       // 예: name 중복 (DB unique 제약 위반) -> 연동 실패
+      log.info("Fail To Create New User From OAuth2 Provider: User Already Exists");
       throw new OAuth2AuthenticationException(
-          new OAuth2Error("INVALID_REQUEST", "이미 존재하는 사용자 정보입니다.", null));
+          new OAuth2Error(ErrorCode.USER_ALREADY_EXISTS.name(),
+              ErrorCode.USER_ALREADY_EXISTS.getMessage(), null));
     }
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -110,10 +110,6 @@ jwt:
     validity-seconds: 2592000 # 30일
   secret: ${JWT_SECRET:dev-secret-key-must-be-at-least-32-characters-long}
 
-time:
-  zone-id: ${TIME_ZONE_ID:Asia/Seoul}
-
-
 resetpassword:
   validity-seconds: 600 # 10분
 

--- a/src/main/resources/templates/email/reset-password.html
+++ b/src/main/resources/templates/email/reset-password.html
@@ -27,7 +27,7 @@
   TEMP_PASSWORD
 </div>
 
-<p style="margin-bottom: 16px;">이 임시 비밀번호는 <strong th:text="${validMinutes}">10분</strong>간 유효합니다.
+<p style="margin-bottom: 16px;">이 임시 비밀번호는 <strong th:text="${validMinutes}">10</strong>분간 유효합니다.
 </p>
 <p style="margin-bottom: 16px;">로그인 후 <strong>반드시 비밀번호를 변경</strong>해주세요.</p>
 


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#219

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

fix/219/user-bug -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- OAuth2 연동 로그인은 잠금 계정이어도 로그인되던 문제 해결
- 임시 비밀번호 발급 이메일 오타 수정
- 리프레시 토큰으로 토큰 재발급 API 동작 안하던 문제 수정

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

- 잠금계정이 소셜 로그인하는 경우
로그인이어도 이 경우에는 프론트에서 401 받을거라는 생각을 안했는지 별도 UI는 없습니다.
<img width="1919" height="441" alt="oauth2잠금계정" src="https://github.com/user-attachments/assets/33b572dc-3fe7-43e8-abf7-da03d974397f" />

<img width="992" height="64" alt="image" src="https://github.com/user-attachments/assets/e0faeeef-d13f-4252-9e4d-5723f606982c" />


### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

--- 

### 추가 코멘트

- 소셜 로그인 시 잠금 처리된 계정이어도 로그인되던 문제는 일반 로그인(email, password 입력)하는 경우 인증 처리를 받는 provider와 OAuth2로 로그인 시 인증 처리를 받는 provider가 달라 발생한 문제입니다. 어떤 파일인지는 코드게시판에 작성하였습니다. [OAuth2 로그인하는 경우 잠금 계정이어도 로그인이 되는 문제](https://www.notion.so/OAuth2-23997c15da088083a026f96e87084fa1)
- 리프레시 토큰으로 토큰 재발급이 안 되던 것은 해당 요청이 만료된 액세스 토큰 때문에 JWT 필터를 통과하지 못해 발생한 문제였습니다.
/api/auth/refresh 요청은 permitAll()로 인증이 필요없는 경로로 설정되어있었지만 필터는 여전히 통과합니다. AuthenticationFilter는 인증이 필요없으므로 통과할 수 있지만 JWT필터는 유효한 액세스 토큰이 없어 통과하지 못했던 것으로, 해당 필터에서 `shouldNotFilter` 메서드를 오버라이딩해 아예 필터링하지 않도록 설정했습니다.
