### PR TITLE
Chore: Nginx 실행 환경별 설정 파일 분리 #230

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - .env.docker
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./nginx/conf.d/local.conf:/etc/nginx/conf.d/default.conf
       - ./src/main/resources/static:/usr/share/nginx/html:ro
     depends_on:
       - backend1

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,7 +3,7 @@ FROM nginx:alpine
 
 # nginx 설정 복사
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
-COPY nginx/conf.d/ /etc/nginx/conf.d/
+COPY nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 
 # 정적 파일 복사
 COPY src/main/resources/static /usr/share/nginx/html

--- a/nginx/conf.d/local.conf
+++ b/nginx/conf.d/local.conf
@@ -1,0 +1,76 @@
+upstream backend {
+    ip_hash;
+    keepalive 32;
+    keepalive_requests 100;
+    keepalive_timeout 60s;
+    server backend1:8080 max_fails=3 fail_timeout=30s;
+}
+
+server {
+    listen 80;
+    server_name localhost; # 서버 이름 > 도메인
+
+    resolver 169.254.169.253 valid=10s;  # ECS VPC DNS
+
+    # / 접속 시
+    location / {
+      root /usr/share/nginx/html;
+      index index.html;
+      try_files $uri $uri/ /index.html;
+    }
+
+    # /api/ 접속 시
+    location /api/ {
+        proxy_pass http://backend;
+
+        # 프록시 헤더 설정
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;                     # 실제 클라이언트 IP
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; # 프록시 체인
+        proxy_set_header X-Forwarded-Proto $scheme;                  # http or https
+        proxy_set_header Authorization $http_authorization;          # 요청을 프록시할 때 Authorization 헤더를 전달
+
+        # 타임아웃 설정
+        proxy_connect_timeout 5s;  # 백엔드 연결 타임아웃
+        proxy_send_timeout 60s;    # 요청 전송 타임아웃
+        proxy_read_timeout 600s;   # 응답 읽기 타임아웃
+        proxy_buffering off;       # SSE 버퍼링 방지
+    }
+
+    location ~ ^/(oauth2|login)/ {
+        proxy_pass http://backend;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 600s;
+        proxy_buffering off;
+    }
+
+    # 웹소켓 및 SSE 프록시 (ex: /ws/ 또는 /api/sse)
+    location /ws/ {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    # 상태 페이지 (선택)
+    location /nginx_status {
+        stub_status on;
+        access_log off;
+        allow 127.0.0.1;
+        deny all;
+    }
+
+    location /health {
+      return 200 'OK';
+      add_header Content-Type text/plain;
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#230 #228 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

chore/230/nginx-env -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

로컬에서도 돌아갈 수 있도록 실행 환경 별 설정 파일을 분리하여 적용하였습니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

실제 docker에서 잘 수행됩니다.

<img width="396" height="427" alt="image" src="https://github.com/user-attachments/assets/f57015c4-a5aa-41bd-9687-254e0a8babb5" />

<img width="1356" height="1006" alt="image" src="https://github.com/user-attachments/assets/2de565b1-5565-4fa7-bed7-0992542e06f3" />

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

### 🔊 추가 코멘트
#### Nginx 설정 파일을 분리한 이유
이전 배포 workflow를 수정하면서, 스크립트가 잘 배포되는 것이 우선이라고 생각하여 로컬 도커 환경에 대해 고려를 하지 않고 nginx를 수정하였습니다. (추후 할 일로 미뤄두었습니다.)
그러던 중, 원재님이 Kafka 환경 분리를 진행하시다보니, 로컬 도커 환경에서도 돌아갈 수 있도록 하는 부분을 빠르게 처리하는 것이 좋다고 판단하여 픽스한 내용이었습니다.

아직 AWS에 대해 잘 알지 않아 기존에 세팅했던 것을 기반으로 수행하다보니,
Bridge 네트워크에서는 지정한 컨테이너 명이 아니라 지정한 컨테이너 명에 추가적인 해시 코드와 같은 값들이 배포 시 붙어 컨테이너에 올라가게 됩니다.
따라서, 제가 backend 라고 지정을 해 두어도 otboo-service-backend-(랜덤한 코드)가 붙어서 컨테이너 명이 생기는 상황이었습니다.

현재는 다중 인스턴스화 하여 배포할 계획이 없어 우선적으로 클러스터에 연동되어 있는 인스턴스의 Private IP를 통해 접근할 수 있도록 조치하여 배포를 성공적으로 진행하였습니다.

하지만 이는 Private IP이기에 로컬에서 해당 conf 파일을 이용한다면 리버스 프록시가 진행되지 않을 터라, nginx template를 통해 환경 변수를 주입하는 방식으로 진행할 지 고민을 하다 local.conf 파일을 만들어 로컬에서는 해당 파일을 default.conf 파일로 사용하는 방식으로 진행하기로 결정했습니다. 배포 시에는 원래 가지고 있던 default.conf 파일을 그대로 배포하는 방식입니다.
추후 로컬에서 nginx의 설정을 바꾸거나 실험해 보기에도 좋을 것 같아 이와 같이 결정하여 적용하였습니다.