### PR TITLE
Fix: 피드 관련 버그 리포트 해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - "${DB_PORT}:5432"
     volumes:
       - otboo-postgres-data:/var/lib/postgresql/data
-      - ./src/main/resources/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+      - ./db/init/schema.sql:/docker-entrypoint-initdb.d/schema.sql
     networks:
       - otboo-network
 

--- a/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/controller/FeedController.java
@@ -50,7 +50,7 @@ public class FeedController implements FeedApi {
   }
 
   // 피드 갱신 (정보 업데이트)
-  @PreAuthorize("@authorizationEvaluator.isFeedAuthor(#feedId, authentication.principal.userId)")
+  @PreAuthorize("@authorizationEvaluator.isFeedAuthor(authentication.principal.userId, #feedId)")
   @PatchMapping("/{feedId}")
   public ResponseEntity<FeedDto> updateFeed(
       @PathVariable UUID feedId,
@@ -61,7 +61,7 @@ public class FeedController implements FeedApi {
   }
 
   // 피드 삭제
-  @PreAuthorize("hasRole('ADMIN') or @authorizationEvaluator.isFeedAuthor(#feedId, authentication.principal.userId)")
+  @PreAuthorize("@authorizationEvaluator.isFeedAuthor(authentication.principal.userId, #feedId)")
   @DeleteMapping("/{feedId}")
   public ResponseEntity<Void> deleteFeed(@PathVariable UUID feedId,
       @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImpl.java
@@ -15,6 +15,7 @@ import com.codeit.weatherwear.domain.follow.dto.UserSummaryDto;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.event.DomainEventPublisher;
 import com.codeit.weatherwear.global.event.dto.NewFeedCommentEvent;
 import com.codeit.weatherwear.global.response.PageResponse;
 import java.util.List;
@@ -23,7 +24,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +38,7 @@ public class FeedCommentServiceImpl implements FeedCommentService {
   private final UserRepository userRepository;
 
   private final FeedCommentMapper feedCommentMapper;
-  private final ApplicationEventPublisher applicationEventPublisher;
+  private final DomainEventPublisher domainEventPublisher;
 
   @Transactional
   @Override
@@ -56,7 +56,7 @@ public class FeedCommentServiceImpl implements FeedCommentService {
     UserSummaryDto userSummary = UserSummaryDto.from(saved.getAuthor());
     FeedCommentDto feedCommentDto = feedCommentMapper.toDto(saved, userSummary);
     log.info("Create feed comment complete: {}", feedCommentDto.getId());
-    applicationEventPublisher.publishEvent(new NewFeedCommentEvent(feed.getAuthor().getId(),
+    domainEventPublisher.publish(new NewFeedCommentEvent(feed.getAuthor().getId(),
         feedCommentDto.getAuthor().name(), feedCommentDto.getContent()));
     return feedCommentDto;
   }

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImpl.java
@@ -15,12 +15,12 @@ import com.codeit.weatherwear.domain.ootd.service.OotdService;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.event.DomainEventPublisher;
 import com.codeit.weatherwear.global.event.dto.FeedLikeEvent;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,7 +37,7 @@ public class FeedLikeServiceImpl implements FeedLikeService {
 
   private final FeedMapper feedMapper;
   private final FeedLikeMapper feedLikeMapper;
-  private final ApplicationEventPublisher applicationEventPublisher;
+  private final DomainEventPublisher domainEventPublisher;
 
   @Transactional
   @Override
@@ -56,7 +56,7 @@ public class FeedLikeServiceImpl implements FeedLikeService {
     FeedDto feedDto = feedMapper.toDto(feed, userSummaryDto, null, ootds, true);
 
     log.info("Add Feed Like Success");
-    applicationEventPublisher.publishEvent(
+    domainEventPublisher.publish(
         new FeedLikeEvent(feed.getAuthor().getId(), user.getName(), feedDto.getContent()));
     return feedDto;
   }

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImpl.java
@@ -23,6 +23,7 @@ import com.codeit.weatherwear.domain.weather.entity.Weather;
 import com.codeit.weatherwear.domain.weather.mapper.WeatherMapper;
 import com.codeit.weatherwear.domain.weather.repository.WeatherRepository;
 import com.codeit.weatherwear.global.response.PageResponse;
+import com.codeit.weatherwear.global.storage.ThumbnailImageStorage;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -45,6 +46,7 @@ public class FeedServiceImpl implements FeedService {
   private final FeedLikeService feedLikeService;
   private final WeatherMapper weatherMapper;
   private final WeatherRepository weatherRepository;
+  private final ThumbnailImageStorage thumbnailImageStorage;
 
   @Transactional
   @Override
@@ -94,7 +96,7 @@ public class FeedServiceImpl implements FeedService {
 
     Feed feed = feedRepository.findById(feedId)
         .orElseThrow(() -> new FeedNotFoundException(feedId));
-    
+
     ootdService.deleteOotdByFeedId(feedId);
     feedLikeService.deleteAllFeedLikeInFeed(feed);
     feedCommentService.deleteFeedCommentsByFeed(feed);
@@ -111,7 +113,14 @@ public class FeedServiceImpl implements FeedService {
 
   // 일반적인 상황 (조회/갱신)
   private FeedDto toFeedDto(Feed feed, UUID currentUserId) {
-    UserSummaryDto authorDto = UserSummaryDto.from(feed.getAuthor());
+    User author = feed.getAuthor();
+    UserSummaryDto authorDto = null;
+    if (author.getProfileImageUrl() != null) {
+      authorDto = UserSummaryDto.from(author,
+          thumbnailImageStorage.get(author.getProfileImageUrl()));
+    } else {
+      authorDto = UserSummaryDto.from(author);
+    }
     WeatherSummaryDto weatherSummaryDto = weatherMapper.toSummaryDto(feed.getWeather());
     List<OotdDto> ootds = ootdService.findOotdByFeedId(feed.getId());
 

--- a/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/service/impl/FeedServiceImpl.java
@@ -94,7 +94,8 @@ public class FeedServiceImpl implements FeedService {
 
     Feed feed = feedRepository.findById(feedId)
         .orElseThrow(() -> new FeedNotFoundException(feedId));
-
+    
+    ootdService.deleteOotdByFeedId(feedId);
     feedLikeService.deleteAllFeedLikeInFeed(feed);
     feedCommentService.deleteFeedCommentsByFeed(feed);
     feedRepository.delete(feed);

--- a/src/main/java/com/codeit/weatherwear/domain/follow/dto/UserSummaryDto.java
+++ b/src/main/java/com/codeit/weatherwear/domain/follow/dto/UserSummaryDto.java
@@ -8,11 +8,20 @@ public record UserSummaryDto(
     String name,
     String profileImageUrl
 ) {
+
   public static UserSummaryDto from(User user) {
     return new UserSummaryDto(
         user.getId(),
         user.getName(),
         user.getProfileImageUrl()
+    );
+  }
+
+  public static UserSummaryDto from(User user, String imageUrl) {
+    return new UserSummaryDto(
+        user.getId(),
+        user.getName(),
+        imageUrl
     );
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherItemProcessor.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/batch/task/WeatherItemProcessor.java
@@ -4,6 +4,7 @@ import com.codeit.weatherwear.domain.location.entity.Location;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
 import com.codeit.weatherwear.domain.weather.entity.Weather;
 import com.codeit.weatherwear.domain.weather.service.WeatherFetchService;
+import com.codeit.weatherwear.global.event.DomainEventPublisher;
 import com.codeit.weatherwear.global.event.dto.WeatherAlertEvent;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -13,7 +14,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.ItemProcessor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
@@ -28,7 +28,7 @@ public class WeatherItemProcessor {
 
   private final WeatherFetchService weatherFetchService;
   private final UserRepository userRepository;
-  private final ApplicationEventPublisher applicationEventPublisher;
+  private final DomainEventPublisher domainEventPublisher;
   private final WeatherAlertAnalyzer weatherAlertAnalyzer;
 
   /**
@@ -71,7 +71,7 @@ public class WeatherItemProcessor {
                 .map(WeatherAlertReason::getCause)
                 .collect(Collectors.joining(", "));
             // 필요한 알람에 대해 이벤트 발행
-            applicationEventPublisher.publishEvent(
+            domainEventPublisher.publish(
                 new WeatherAlertEvent(receiverIds, location.getName(),
                     combinedReason));
           }

--- a/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedCommentServiceImplTest.java
@@ -27,6 +27,7 @@ import com.codeit.weatherwear.domain.user.entity.Role;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
+import com.codeit.weatherwear.global.event.DomainEventPublisher;
 import com.codeit.weatherwear.global.event.dto.NewFeedCommentEvent;
 import com.codeit.weatherwear.global.request.SortDirection;
 import com.codeit.weatherwear.global.response.PageResponse;
@@ -43,7 +44,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -68,7 +68,7 @@ class FeedCommentServiceImplTest {
   private FeedCommentMapper feedCommentMapper;
 
   @Mock
-  private ApplicationEventPublisher applicationEventPublisher;
+  private DomainEventPublisher domainEventPublisher;
 
   private Location mockLocation;
   private UUID authorId;
@@ -198,7 +198,7 @@ class FeedCommentServiceImplTest {
     given(feedCommentMapper.toEntity(feed, author, request.getContent())).willReturn(comment1);
     given(feedCommentRepository.save(comment1)).willReturn(comment1);
     given(feedCommentMapper.toDto(comment1, authorDto)).willReturn(commentDto1);
-    willDoNothing().given(applicationEventPublisher).publishEvent(any(NewFeedCommentEvent.class));
+    willDoNothing().given(domainEventPublisher).publish(any(NewFeedCommentEvent.class));
 
     // when
     FeedCommentDto result = feedCommentService.createFeedComment(feedId, request);

--- a/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/feed/service/impl/FeedLikeServiceImplTest.java
@@ -28,6 +28,7 @@ import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
 import com.codeit.weatherwear.domain.user.repository.UserRepository;
 import com.codeit.weatherwear.domain.weather.entity.Weather;
+import com.codeit.weatherwear.global.event.DomainEventPublisher;
 import com.codeit.weatherwear.global.event.dto.FeedLikeEvent;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -41,7 +42,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -68,7 +68,7 @@ class FeedLikeServiceImplTest {
   private FeedLikeMapper feedLikeMapper;
 
   @Mock
-  private ApplicationEventPublisher applicationEventPublisher;
+  private DomainEventPublisher domainEventPublisher;
 
   private UUID feedId;
   private UUID currentUserId;
@@ -108,7 +108,7 @@ class FeedLikeServiceImplTest {
     given(ootdService.findOotdByFeedId(feedId)).willReturn(ootds);
     given(feedMapper.toDto(any(Feed.class), any(UserSummaryDto.class), any(), anyList(),
         anyBoolean())).willReturn(feedDto);
-    willDoNothing().given(applicationEventPublisher).publishEvent(any(FeedLikeEvent.class));
+    willDoNothing().given(domainEventPublisher).publish(any(FeedLikeEvent.class));
 
     // when
     FeedDto result = feedLikeService.addFeedLike(feedId, currentUserId);


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#229 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

fix/229/fix-feed-bug -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

버그 리포트에 존재하던 피드 관련 버그들을 해결하였습니다.
- 피드 삭제 시 OOTD를 함께 삭제하지 않아, 피드 삭제 로직이 수행되지 않던 버그
- 피드 수정 및 삭제 시 권한 없음으로 API를 요청하지 못하던 버그
- 피드 조회 시 유저 프로필 사진을 불러오지 못하는 버그

그에 추가적으로 진행했던 docker-compose 관련 설정을 일부 수정하였습니다.
- schema.sql의 위치로 인해 로컬에서 application 빌드 중 오류가 발생하였습니다.
- 로컬 도커에서만 필요한 schema.sql을 build 대상에서 제외시기 위해 루트 디렉토리에 db/init 디렉토리를 추가하여 해당 루트에 sql문을 이동하여 사용하게 되었습니다.
- 그에 docker-compose 또한 관련 루트 수정이 필요하기에 해당 부분 함께 수정하였습니다.

<img width="285" height="125" alt="image" src="https://github.com/user-attachments/assets/4b097e38-a582-4516-b3de-71ec0375ce03" />

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

<img width="744" height="377" alt="image" src="https://github.com/user-attachments/assets/235392b1-293c-49c9-b7ee-d4e501437aa3" />

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.