### PR TITLE
Refactor: 구매링크로 옷불러오기 기능 코드리뷰 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,6 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.21.1'
     implementation 'commons-io:commons-io:2.15.1'
 
-
     //웹소켓
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
@@ -151,6 +150,10 @@ dependencies {
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+    //retry
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/exception/cloth/ExtractionException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/exception/cloth/ExtractionException.java
@@ -9,4 +9,8 @@ public class ExtractionException extends CustomException {
   public ExtractionException(String url) {
     super(ErrorCode.CLOTH_EXTRACTION_ERROR, Map.of("url", url));
   }
+
+  public ExtractionException() {
+    super(ErrorCode.CLOTH_EXTRACTION_ERROR);
+  }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothService.java
@@ -5,7 +5,6 @@ import com.codeit.weatherwear.domain.clothes.dto.request.ClothesSearchRequest;
 import com.codeit.weatherwear.domain.clothes.dto.request.ClothesUpdateRequest;
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
 import com.codeit.weatherwear.global.response.PageResponse;
-import java.io.IOException;
 import java.util.UUID;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothService.java
@@ -13,7 +13,7 @@ public interface ClothService {
 
   ClothesDto create(ClothesCreateRequest request, MultipartFile image);
 
-  ClothesDto getFromUrl(String url) throws IOException;
+  ClothesDto getFromUrl(String url);
 
   ClothesDto update(UUID clothesId, ClothesUpdateRequest request, MultipartFile image);
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothService.java
@@ -5,6 +5,7 @@ import com.codeit.weatherwear.domain.clothes.dto.request.ClothesSearchRequest;
 import com.codeit.weatherwear.domain.clothes.dto.request.ClothesUpdateRequest;
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
 import com.codeit.weatherwear.global.response.PageResponse;
+import java.io.IOException;
 import java.util.UUID;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -12,7 +13,7 @@ public interface ClothService {
 
   ClothesDto create(ClothesCreateRequest request, MultipartFile image);
 
-  ClothesDto getFromUrl(String url);
+  ClothesDto getFromUrl(String url) throws IOException;
 
   ClothesDto update(UUID clothesId, ClothesUpdateRequest request, MultipartFile image);
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -119,12 +119,13 @@ public class ClothServiceImpl implements ClothService {
   @Override
   public ClothesDto getFromUrl(String url) {
     log.info("[Start Getting Cloth From Url] URL: {}", url);
-    Document document = null;
+    Document document;
     try {
       document = Jsoup.connect(url)
           .timeout(15000)
           .userAgent("Mozilla/5.0")
           .get();
+
       SiteParser parser = siteParsers.stream()
           .filter(p -> p.supports(url))
           .findFirst()

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -126,7 +126,8 @@ public class ClothServiceImpl implements ClothService {
       maxAttempts = 3,
       backoff = @Backoff(delay = 2000),
       recover = "recover",
-      retryFor = {RuntimeException.class}
+      retryFor = {RuntimeException.class},
+      noRetryFor = {NotSupportSiteException.class}
   )
   @Override
   public ClothesDto getFromUrl(String url) {
@@ -149,9 +150,12 @@ public class ClothServiceImpl implements ClothService {
             return new NotSupportSiteException(url);
           });
       return parser.extract(document);
-    } catch (RuntimeException | IOException e) {
+    } catch (IOException e) {
       log.warn("[Fail Getting Cloth From Url] Retry count: {}", retryCount);
       throw new RuntimeException(e);
+    } catch (RuntimeException e) {
+      log.warn("[Fail Getting Cloth From Url] Retry count: {}", retryCount);
+      throw e;
     }
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -31,6 +31,7 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -40,9 +41,11 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
 import org.springframework.data.domain.Slice;
+import org.springframework.retry.RetryContext;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.support.RetrySynchronizationManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -123,11 +126,15 @@ public class ClothServiceImpl implements ClothService {
       maxAttempts = 3,
       backoff = @Backoff(delay = 2000),
       recover = "recover",
-      retryFor = {RuntimeException.class, IOException.class}
+      retryFor = {RuntimeException.class}
   )
   @Override
-  public ClothesDto getFromUrl(String url) throws IOException {
+  public ClothesDto getFromUrl(String url) {
     log.info("[Start Getting Cloth From Url] URL: {}", url);
+    int retryCount = Optional.ofNullable(RetrySynchronizationManager.getContext())
+        .map(RetryContext::getRetryCount)
+        .orElse(0);
+    retryCount += 1;
     try {
       Document document = Jsoup.connect(url)
           .timeout(15000)
@@ -143,14 +150,14 @@ public class ClothServiceImpl implements ClothService {
           });
       return parser.extract(document);
     } catch (RuntimeException | IOException e) {
-      log.warn("[Fail Getting Cloth From Url] URL: {}", url, e);
-      throw e;
+      log.warn("[Fail Getting Cloth From Url] Retry count: {}", retryCount);
+      throw new RuntimeException(e);
     }
   }
 
   @Recover
   public ClothesDto recover(RuntimeException e, String url) {
-    log.warn("[Recover] Retry failed for URL: {}", url, e);
+    log.warn("[Recover] Retry failed for URL: {}", url);
     throw new ExtractionException(url);
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -134,8 +134,7 @@ public class ClothServiceImpl implements ClothService {
     log.info("[Start Getting Cloth From Url] URL: {}", url);
     int retryCount = Optional.ofNullable(RetrySynchronizationManager.getContext())
         .map(RetryContext::getRetryCount)
-        .orElse(0);
-    retryCount += 1;
+        .orElse(1);
     try {
       Document document = Jsoup.connect(url)
           .timeout(15000)

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -40,6 +40,9 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
 import org.springframework.data.domain.Slice;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -116,12 +119,17 @@ public class ClothServiceImpl implements ClothService {
    * @return 의상 DTO
    * @throws RuntimeException, IOException
    */
+  @Retryable(
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 2000),
+      recover = "recover",
+      retryFor = {RuntimeException.class, IOException.class}
+  )
   @Override
-  public ClothesDto getFromUrl(String url) {
+  public ClothesDto getFromUrl(String url) throws IOException {
     log.info("[Start Getting Cloth From Url] URL: {}", url);
-    Document document;
     try {
-      document = Jsoup.connect(url)
+      Document document = Jsoup.connect(url)
           .timeout(15000)
           .userAgent("Mozilla/5.0")
           .get();
@@ -136,8 +144,14 @@ public class ClothServiceImpl implements ClothService {
       return parser.extract(document);
     } catch (RuntimeException | IOException e) {
       log.warn("[Fail Getting Cloth From Url] URL: {}", url, e);
-      throw new ExtractionException(url);
+      throw e;
     }
+  }
+
+  @Recover
+  public ClothesDto recover(RuntimeException e, String url) {
+    log.warn("[Recover] Retry failed for URL: {}", url, e);
+    throw new ExtractionException(url);
   }
 
   /**

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/AbstractTagParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/AbstractTagParser.java
@@ -1,0 +1,23 @@
+package com.codeit.weatherwear.domain.clothes.service.parser;
+
+import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+@Slf4j
+public abstract class AbstractTagParser implements SiteParser {
+
+  protected ClothesDto buildFromMetaTag(Document document, String siteName) {
+    String name = document.title();
+    String imageUrl = extractOgImage(document);
+
+    log.info("[Extracting Cloth Completed : {}, Name: {}", siteName, name);
+    return ClothesDto.builder().name(name).imageUrl(imageUrl).build();
+  }
+
+  private String extractOgImage(Document document) {
+    Element ogImageTag = document.selectFirst("meta[property=og:image]");
+    return ogImageTag != null ? ogImageTag.attr("content") : null;
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
@@ -1,6 +1,7 @@
 package com.codeit.weatherwear.domain.clothes.service.parser;
 
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
+import com.codeit.weatherwear.domain.clothes.exception.cloth.ExtractionException;
 import com.codeit.weatherwear.domain.clothes.exception.cloth.ExtractionNotFoundException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,8 +27,6 @@ public class MusinsaParser implements SiteParser {
   @Override
   public ClothesDto extract(Document document) {
     log.info("[Start Extracting Musinsa Cloth]");
-    String productName = "";
-    String thumbnailImageUrl = "";
     try {
       Element scriptTag = document.selectFirst("script#pdp-data");
       if (scriptTag != null) {
@@ -40,24 +39,26 @@ public class MusinsaParser implements SiteParser {
           ObjectMapper objectMapper = new ObjectMapper();
           JsonNode jsonNode = objectMapper.readTree(jsonString);
 
-          productName = jsonNode.get("goodsNm").asText();
-          thumbnailImageUrl =
-              mssCdnImageUrlPrefix + jsonNode.get("thumbnailImageUrl").asText();
+          JsonNode goodsNmNode = jsonNode.get("goodsNm");
+          JsonNode thumbnailNode = jsonNode.get("thumbnailImageUrl");
+
+          if (goodsNmNode == null || thumbnailNode == null) {
+            throw new ExtractionNotFoundException();
+          }
+
+          String productName = goodsNmNode.asText();
+          String thumbnailImageUrl =
+              mssCdnImageUrlPrefix + thumbnailNode.asText();
           log.info("[Extracting Cloth Completed : {}, Name: {}", "무신사", productName);
           return ClothesDto.builder()
               .name(productName)
               .imageUrl(thumbnailImageUrl)
               .build();
         }
-        throw new ExtractionNotFoundException();
       }
+      throw new ExtractionException();
     } catch (IOException e) {
-      //clothService에서 커스텀 처리 진행
       throw new RuntimeException(e);
     }
-    return ClothesDto.builder()
-        .name(productName)
-        .imageUrl(thumbnailImageUrl)
-        .build();
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
@@ -3,12 +3,11 @@ package com.codeit.weatherwear.domain.clothes.service.parser;
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class TwentyNineCmParser implements SiteParser {
+public class TwentyNineCmParser extends AbstractTagParser {
 
   @Override
   public boolean supports(String url) {
@@ -18,18 +17,7 @@ public class TwentyNineCmParser implements SiteParser {
   @Override
   public ClothesDto extract(Document document) {
     log.info("[Start Extracting 29cm Cloth]");
-    String productName;
-    String thumbnailImageUrl;
-
-    productName = document.title();
-    // 썸네일 (og:image)
-    Element ogImageTag = document.selectFirst("meta[property=og:image]");
-    thumbnailImageUrl = ogImageTag != null ? ogImageTag.attr("content") : null;
-    log.info("[Extracting Cloth Completed : {}, Name: {}", "29cm", productName);
-    return ClothesDto.builder()
-        .name(productName)
-        .imageUrl(thumbnailImageUrl)
-        .build();
+    return buildFromMetaTag(document, "29CM");
   }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
@@ -3,32 +3,20 @@ package com.codeit.weatherwear.domain.clothes.service.parser;
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class ZigZagParser implements SiteParser {
+public class ZigZagParser extends AbstractTagParser {
 
   @Override
   public boolean supports(String url) {
-    return url.toLowerCase().contains("zigzag.kr");
+    return url != null && url.matches("https?://(www\\.)?zigzag\\.kr/.*");
   }
 
   @Override
   public ClothesDto extract(Document document) {
     log.info("[Start Extracting ZigZag Cloth]");
-    String productName;
-    String thumbnailImageUrl;
-
-    productName = document.title();
-    // 썸네일 (og:image)
-    Element ogImageTag = document.selectFirst("meta[property=og:image]");
-    thumbnailImageUrl = ogImageTag != null ? ogImageTag.attr("content") : null;
-    log.info("[Extracting Cloth Completed : {}, Name: {}", "지그재그", productName);
-    return ClothesDto.builder()
-        .name(productName)
-        .imageUrl(thumbnailImageUrl)
-        .build();
+    return buildFromMetaTag(document, "지그재그");
   }
 }

--- a/src/main/java/com/codeit/weatherwear/global/config/RetryConfig.java
+++ b/src/main/java/com/codeit/weatherwear/global/config/RetryConfig.java
@@ -1,0 +1,10 @@
+package com.codeit.weatherwear.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #237 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> refactor/237/cloth-from-url -> dev

### 📑 변경 사항
1. 29cm Parser, Zigzag Parser에서 중복되는 메서드를 추상클래스를 통해 해결하였습니다.
2. 구매링크로 옷 불러오는 시도를 retry할 수 있도록 설정하였습니다.

### 🛠 테스트 결과
> 
<img width="756" height="226" alt="스크린샷 2025-07-25 오후 4 26 13" src="https://github.com/user-attachments/assets/84bd7cd1-b5a5-4949-b23e-4a6ad6712c74" />


### ✅ PR 올리기 전 체크리스트

- [ ] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [ ] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.

### 추가코멘트
1. MusinsaParser에서 `throw e`안하는 이유
IOException은 체크 예외여서 RuntimeException으로 감싸지 않으면 컴파일 에러 발생
2. 구매링크로 옷 불러오는 시도를 3번까지 허용합니다. 3번째 시도시, 실패할 경우 `ExtractionException`이 발생합니다.