### PR TITLE
Fix: 날씨, 위치 도메인 관련 버그 리포트 해결

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/feed/repository/FeedRepository.java
@@ -1,11 +1,18 @@
 package com.codeit.weatherwear.domain.feed.repository;
 
 import com.codeit.weatherwear.domain.feed.entity.Feed;
+import com.codeit.weatherwear.domain.weather.entity.Weather;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedRepository extends JpaRepository<Feed, UUID>, FeedCustomRepository {
 
+  // 현재 Feed에서 사용하고 있는 날씨의 ID 리스트 반환
+  @Query("SELECT f.weather.id FROM Feed f WHERE f.weather IN :weatherList")
+  List<UUID> findWeatherIdsInUse(@Param("weatherList") List<Weather> weatherList);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/location/repository/LocationRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/repository/LocationRepository.java
@@ -9,8 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface LocationRepository extends JpaRepository<Location, UUID> {
 
-  Optional<Location> findLocationByNameAndLatitudeAndLongitude(String name, double latitude,
-      double longitude);
+  Optional<Location> findLocationByName(String name);
 
   Optional<Location> findByLatitudeAndLongitude(double latitude, double longitude);
 

--- a/src/main/java/com/codeit/weatherwear/domain/location/service/LocationServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/service/LocationServiceImpl.java
@@ -43,11 +43,9 @@ public class LocationServiceImpl implements LocationService {
         locationName
     );
 
-    // 이미 존재하면 기존 객체 반환
-    Location resultLocation = locationRepository.findLocationByNameAndLatitudeAndLongitude(
-        location.getName(),
-        location.getLatitude(),
-        location.getLongitude()
+    // 위치 지명이 이미 존재하면 기존 객체 반환
+    Location resultLocation = locationRepository.findLocationByName(
+        location.getName()
     ).orElseGet(() -> locationRepository.save(location));
 
     log.info("Find Or Create Location Success");

--- a/src/main/java/com/codeit/weatherwear/domain/weather/api/WeatherApiClient.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/api/WeatherApiClient.java
@@ -67,6 +67,7 @@ public class WeatherApiClient {
       // 응답 Body 전달
       return response.body();
     } catch (IOException | InterruptedException e) {
+      log.info("url: {}", requestUrl);
       log.error("Weather Api Request Invalid - cause: {}\nmessage: {}", e.getCause(),
           e.getMessage());
       throw new WeatherApiRequestException();

--- a/src/main/java/com/codeit/weatherwear/domain/weather/assembler/WeatherAssembler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/assembler/WeatherAssembler.java
@@ -10,7 +10,6 @@ import com.codeit.weatherwear.domain.weather.entity.Weather;
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiData;
 import com.codeit.weatherwear.domain.weather.entity.WindSpeed;
 import com.codeit.weatherwear.domain.weather.support.WeatherCalculationHelper;
-import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -40,25 +39,24 @@ public class WeatherAssembler {
       String baseDate,
       Map<String, WeatherApiData> categoryMap,
       Location location,
-      Map<String, Map<String, List<WeatherApiData>>> groupedApiData
+      Weather compareWeather
   ) {
-    // categoryMap에서 예보 시간 중 가장 이른(fcstTime) 값을 추출
-    String fcstTime = helper.extractMinForecastTime(categoryMap);
-
     // 현재 습도 값 파싱
     Double currentHumidity = helper.parseDoubleOrNull(helper.getFcstValue(categoryMap, "REH"));
-    // 전일 대비 습도 변화랑 계산
-    Double comparedHumidity = helper.calculateDifferenceFromPreviousDay(currentHumidity, "REH",
-        fcstDate, fcstTime,
-        groupedApiData);
 
-    // todo: 기온 값 등이 없다고 해서 변화량을 0이라고 둬도 되나? null로 두는 것이 나을까? (고민)
     // 현재 기온 값 파싱
     Double currentTemperature = helper.parseDoubleOrNull(helper.getFcstValue(categoryMap, "TMP"));
-    // 전일 대비 기온 변화량 계산
-    Double comparedTemperature = helper.calculateDifferenceFromPreviousDay(currentTemperature,
-        "TMP", fcstDate, fcstTime,
-        groupedApiData);
+
+    // 변화량 계산
+    Double comparedHumidity = 0.0;
+    Double comparedTemperature = 0.0;
+
+    if (compareWeather != null) {
+      // 전일 대비 습도 변화랑 계산
+      comparedHumidity = currentHumidity - compareWeather.getHumidity().getCurrent();
+      // 전일 대비 기온 변화량 계산
+      comparedTemperature = currentTemperature - compareWeather.getTemperature().getCurrent();
+    }
 
     // 최고 기온 값 파싱 (해당 카테고리가 없을 때는 0)
     Double tmx = helper.parseMinMaxTempDoubleOrNull(categoryMap.get("TMX"));

--- a/src/main/java/com/codeit/weatherwear/domain/weather/batch/scheduler/WeatherBatchScheduler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/batch/scheduler/WeatherBatchScheduler.java
@@ -1,9 +1,15 @@
 package com.codeit.weatherwear.domain.weather.batch.scheduler;
 
+import com.codeit.weatherwear.domain.weather.repository.WeatherRepository;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
@@ -17,10 +23,12 @@ public class WeatherBatchScheduler {
 
   private final JobLauncher jobLauncher;
   private final Job weatherFetchJob;
+  private final WeatherRepository weatherRepository;
 
   // 매일 3시 10분에 돌아가는 스케줄러
   // -> 예보 데이터를 정시가 아닌 정시 + 10분에 준다고 해서 해당 시각으로 설정
-  @Scheduled(cron = "0 10 3 * * ?", zone = "Asia/Seoul")
+//  @Scheduled(cron = "0 10 3 * * ?", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 22 0 * * ?", zone = "Asia/Seoul")
   public void runWeatherBatchJob() {
     Date date = new Date();
     JobParameters parameters = new JobParametersBuilder()
@@ -29,10 +37,25 @@ public class WeatherBatchScheduler {
 
     try {
       log.info(">> Weather Fetch Batch Job Start at {}", date);
-      jobLauncher.run(weatherFetchJob, parameters);
+      JobExecution execution = jobLauncher.run(weatherFetchJob, parameters);
+
+      if (execution.getStatus() == BatchStatus.COMPLETED) {
+        log.info(">> Weather Fetch Batch Job Completed, Starting Delete");
+        cleanOldOrphanWeather();
+      }
+
     } catch (Exception e) {
       log.error(">> Weather Fetch Batch Job Failed", e);
     }
+  }
+
+  public void cleanOldOrphanWeather() {
+    ZoneId zone = ZoneId.of("Asia/Seoul");
+    LocalDate today = LocalDate.now(zone);
+    Instant cutOffTime = today.atStartOfDay(zone).toInstant();
+
+    int deletedCount = weatherRepository.deleteOldOrphanForecast(cutOffTime);
+    log.info(">> Deleted {} old orphan Weather records", deletedCount);
   }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/batch/scheduler/WeatherBatchScheduler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/batch/scheduler/WeatherBatchScheduler.java
@@ -27,8 +27,7 @@ public class WeatherBatchScheduler {
 
   // 매일 3시 10분에 돌아가는 스케줄러
   // -> 예보 데이터를 정시가 아닌 정시 + 10분에 준다고 해서 해당 시각으로 설정
-//  @Scheduled(cron = "0 10 3 * * ?", zone = "Asia/Seoul")
-  @Scheduled(cron = "0 22 0 * * ?", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 10 3 * * ?", zone = "Asia/Seoul")
   public void runWeatherBatchJob() {
     Date date = new Date();
     JobParameters parameters = new JobParametersBuilder()

--- a/src/main/java/com/codeit/weatherwear/domain/weather/parser/WeatherApiParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/parser/WeatherApiParser.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
@@ -74,8 +75,13 @@ public class WeatherApiParser {
       Map<String, Map<String, List<WeatherApiData>>> groupedByDateAndTime =
           parsedDataList.stream()
               .collect(Collectors.groupingBy(
-                  WeatherApiData::getFcstDate,
-                  Collectors.groupingBy(WeatherApiData::getFcstTime)
+                  WeatherApiData::getFcstDate,      // fcstDate 기준 오름차순 정렬
+                  TreeMap::new,                     // → 날짜 기준으로 정렬된 TreeMap 생성
+                  Collectors.groupingBy(
+                      WeatherApiData::getFcstTime,  // fcstTime 기준 오름차순 정렬
+                      TreeMap::new,                 // → 시간 기준으로 정렬된 TreeMap 생성
+                      Collectors.toList()           // 해당 시간대 예보 데이터를 리스트로 수정
+                  )
               ));
 
       return groupedByDateAndTime;

--- a/src/main/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepository.java
@@ -32,10 +32,6 @@ public interface WeatherRepository extends JpaRepository<Weather, UUID> {
       @Param("end") Instant end,
       Pageable pageable);
 
-  @Query("SELECT w FROM Weather w WHERE w.location = :location AND w.forecastAt < :target")
-  List<Weather> getOldForecast(@Param("location") Location location,
-      @Param("target") Instant cutoffTime);
-
   /**
    * 1. 피드와 연결되어 있는 날씨가 아니고
    * <p>

--- a/src/main/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepository.java
@@ -5,6 +5,7 @@ import com.codeit.weatherwear.domain.weather.entity.Weather;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,7 +17,20 @@ public interface WeatherRepository extends JpaRepository<Weather, UUID> {
 
   @Query("SELECT w FROM Weather w WHERE w.location = :location AND w.forecastedAt >= :start AND w.forecastAt >= :start")
   List<Weather> findRecentWeathers(@Param("location") Location location,
-      @Param("start") Instant todayStart);
+      @Param("start") Instant start);
+
+  @Query("""
+          SELECT w FROM Weather w
+          WHERE w.location = :location
+            AND w.forecastAt >= :start
+            AND w.forecastAt <= :end
+          ORDER BY w.forecastedAt DESC
+      """)
+  List<Weather> findOneDayWeather(
+      @Param("location") Location location,
+      @Param("start") Instant start,
+      @Param("end") Instant end,
+      Pageable pageable);
 
   @Query("SELECT w FROM Weather w WHERE w.location = :location AND w.forecastAt < :target")
   List<Weather> getOldForecast(@Param("location") Location location,

--- a/src/main/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepository.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -20,4 +21,18 @@ public interface WeatherRepository extends JpaRepository<Weather, UUID> {
   @Query("SELECT w FROM Weather w WHERE w.location = :location AND w.forecastAt < :target")
   List<Weather> getOldForecast(@Param("location") Location location,
       @Param("target") Instant cutoffTime);
+
+  /**
+   * 1. 피드와 연결되어 있는 날씨가 아니고
+   * <p>
+   * 2. 예보 요청 시간(forecastedAt)이 기준 시간(조회 당일) 이전이거나 예보 시간(forecastAt)이 기준 시간(조회 당일) 이전이라면 삭제
+   */
+  @Modifying
+  @Query("""
+      DELETE FROM Weather w
+          WHERE w.location = :location
+             AND (w.forecastAt < :cutOffTime OR w.forecastedAt < :cutOffTime)
+             AND NOT EXISTS (SELECT 1 FROM Feed f WHERE f.weather.id = w.id)""")
+  int deleteOldOrphanForecast(@Param("location") Location location,
+      @Param("cutOffTime") Instant cutOffTime);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface WeatherRepository extends JpaRepository<Weather, UUID> {
@@ -37,12 +38,12 @@ public interface WeatherRepository extends JpaRepository<Weather, UUID> {
    * <p>
    * 2. 예보 요청 시간(forecastedAt)이 기준 시간(조회 당일) 이전이거나 예보 시간(forecastAt)이 기준 시간(조회 당일) 이전이라면 삭제
    */
-  @Modifying
+  @Modifying(clearAutomatically = true)
+  @Transactional
   @Query("""
       DELETE FROM Weather w
-          WHERE w.location = :location
-             AND (w.forecastAt < :cutOffTime OR w.forecastedAt < :cutOffTime)
+          WHERE
+             (w.forecastAt < :cutOffTime OR w.forecastedAt < :cutOffTime)
              AND NOT EXISTS (SELECT 1 FROM Feed f WHERE f.weather.id = w.id)""")
-  int deleteOldOrphanForecast(@Param("location") Location location,
-      @Param("cutOffTime") Instant cutOffTime);
+  int deleteOldOrphanForecast(@Param("cutOffTime") Instant cutOffTime);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherConvertServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherConvertServiceImpl.java
@@ -5,10 +5,13 @@ import com.codeit.weatherwear.domain.weather.assembler.WeatherAssembler;
 import com.codeit.weatherwear.domain.weather.entity.Weather;
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiData;
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiDataId;
+import com.codeit.weatherwear.domain.weather.repository.WeatherRepository;
 import com.codeit.weatherwear.domain.weather.service.WeatherConvertService;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -17,6 +20,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -25,6 +29,7 @@ import org.springframework.stereotype.Service;
 public class WeatherConvertServiceImpl implements WeatherConvertService {
 
   private final WeatherAssembler weatherAssembler;
+  private final WeatherRepository weatherRepository;
 
   /**
    * 변환 수행 메서드
@@ -36,16 +41,21 @@ public class WeatherConvertServiceImpl implements WeatherConvertService {
   @Override
   public List<Weather> convert(Map<String, Map<String, List<WeatherApiData>>> groupedApiData,
       Location location) {
-    List<Weather> result = new ArrayList<>();
+    Map<String, Weather> dateToWeatherMap = new HashMap<>();
 
     // groupedApiData 에서 날짜별 데이터를 순회하며 변환 수행 후,
     // 결과가 존재할 경우 result 에 추가
     for (Map.Entry<String, Map<String, List<WeatherApiData>>> dateEntry : groupedApiData.entrySet()) {
-      convertForecastDay(dateEntry.getKey(), dateEntry.getValue(), groupedApiData,
-          location).ifPresent(result::add);
+
+      Weather compareWeather = getCompareWeather(dateToWeatherMap, location, dateEntry.getKey());
+
+      convertForecastDay(dateEntry.getKey(), dateEntry.getValue(), compareWeather,
+          location).ifPresent(weather -> {
+        dateToWeatherMap.put(dateEntry.getKey(), weather);
+      });
     }
 
-    return result;
+    return dateToWeatherMap.values().stream().collect(Collectors.toList());
   }
 
   /**
@@ -58,7 +68,7 @@ public class WeatherConvertServiceImpl implements WeatherConvertService {
   private Optional<Weather> convertForecastDay(
       String fcstDate,
       Map<String, List<WeatherApiData>> timeMap,
-      Map<String, Map<String, List<WeatherApiData>>> groupedApiData,
+      Weather compareWeather,
       Location location
   ) {
     // 시간별 예보 데이터를 평탄화 하여 하나의 리스트로 만듦
@@ -93,7 +103,7 @@ public class WeatherConvertServiceImpl implements WeatherConvertService {
     try {
       // WeatherAssembler를 이용하여 Weather 객체 생성
       return Optional.ofNullable(
-          weatherAssembler.assemble(fcstDate, baseDate, categoryMap, location, groupedApiData));
+          weatherAssembler.assemble(fcstDate, baseDate, categoryMap, location, compareWeather));
     } catch (Exception e) {
       // 변환 실패 시 로그 출력 후 Optional.empty() 반환
       log.error("날짜 {} → 변환 실패: {}", fcstDate, e.getMessage());
@@ -184,6 +194,34 @@ public class WeatherConvertServiceImpl implements WeatherConvertService {
         categoryMap.put("TMX", tmnData);
       });
     }
+  }
+
+  private Weather getCompareWeather(Map<String, Weather> dateToWeatherMap, Location location,
+      String fcstDate) {
+    DateTimeFormatter formatter = DateTimeFormatter.BASIC_ISO_DATE; // "yyyyMMdd" 포맷
+    ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    // 현재 시간/이전 시간 Instant 화
+    LocalDate fcstLocalDate = LocalDate.parse(fcstDate, formatter);
+    LocalDate prevLocalDate = fcstLocalDate.minusDays(1);
+    String prevDate = prevLocalDate.format(formatter);
+    Instant prev = prevLocalDate.atStartOfDay(KST).toInstant();
+    Instant fcst = fcstLocalDate.atStartOfDay(KST).toInstant();
+
+    Weather compareWeather;
+    if (dateToWeatherMap.containsKey(prevDate)) {
+      compareWeather = dateToWeatherMap.get(prevDate);
+    } else {
+      List<Weather> oneDayWeather = weatherRepository.findOneDayWeather(
+          location,
+          prev,
+          fcst,
+          PageRequest.of(0, 1)
+      );
+      compareWeather = oneDayWeather.isEmpty() ? null : oneDayWeather.get(0);
+    }
+
+    return compareWeather;
   }
 }
 

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImpl.java
@@ -1,6 +1,5 @@
 package com.codeit.weatherwear.domain.weather.service.impl;
 
-import com.codeit.weatherwear.domain.feed.repository.FeedRepository;
 import com.codeit.weatherwear.domain.location.entity.Location;
 import com.codeit.weatherwear.domain.location.service.LocationService;
 import com.codeit.weatherwear.domain.weather.api.WeatherApiClient;
@@ -20,12 +19,8 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.repository.Modifying;
@@ -53,7 +48,6 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
 
   private final WeatherApiClient weatherApiClient;
   private final WeatherApiParser weatherApiParser;
-  private final FeedRepository feedRepository;
 
   /**
    * 기상청 단기 예보 API 요청 및 데이터 파싱을 거쳐 나온<br>날씨 데이터를 저장하고 반환
@@ -62,6 +56,9 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
    * @param longitude 경도
    * @return 날씨 엔티티 리스트
    */
+  // 쿼리가 실행된 후 영속성 컨텍스트를 자동으로 clear()하여 캐시된 엔티티 비움
+  // 삭제 쿼리를 @Modifying을 통해 JPA의 Dirty Checking을 거치지 않고 직접 SQL로 수행하도록 했기에 아래 어노테이션 추가
+  // 기존 날씨 예보 엔티티 삭제는 대량 삭제에 해당되어서 빠르게 수행하는 것이 더 좋다고 생각
   @Modifying(clearAutomatically = true)
   @Transactional
   @Override
@@ -76,7 +73,6 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
     }
 
     // 이전 데이터 삭제
-//    deleteOldForecast(weatherList.get(0).getLocation());
     Instant cutoffTime = LocalDate.now(KST).atStartOfDay(KST).toInstant();
     int deleted = weatherRepository.deleteOldOrphanForecast(weatherList.get(0).getLocation(),
         cutoffTime);
@@ -155,26 +151,4 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
         // 아무것도 없으면 기본 값 제공
         .orElse("0200");
   }
-
-  private void deleteOldForecast(Location location) {
-    // 자를 시간
-    Instant cutoffTime = LocalDate.now(KST).atStartOfDay(KST).toInstant();
-
-    // 시간 기준 이전 데이터(오래된 예보 데이터) 가져오기
-    List<Weather> oldForecast = weatherRepository.getOldForecast(location,
-        cutoffTime);
-
-    // Feed에 사용 중인 날씨 ID 가져오기
-    List<UUID> weatherIdsInUse = feedRepository.findWeatherIdsInUse(oldForecast);
-    Set<UUID> weatherIdsInUseSet = new HashSet<>(weatherIdsInUse);
-
-    // 필터링
-    List<Weather> deleteTarget = oldForecast.stream()
-        .filter(weather -> !weatherIdsInUseSet.contains(weather.getId()))
-        .collect(Collectors.toList());
-
-    // 필터링 된 날씨 데이터만 삭제
-    weatherRepository.deleteAll(deleteTarget);
-  }
-
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImpl.java
@@ -1,5 +1,6 @@
 package com.codeit.weatherwear.domain.weather.service.impl;
 
+import com.codeit.weatherwear.domain.feed.repository.FeedRepository;
 import com.codeit.weatherwear.domain.location.entity.Location;
 import com.codeit.weatherwear.domain.location.service.LocationService;
 import com.codeit.weatherwear.domain.weather.api.WeatherApiClient;
@@ -19,8 +20,12 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.repository.Modifying;
@@ -48,6 +53,7 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
 
   private final WeatherApiClient weatherApiClient;
   private final WeatherApiParser weatherApiParser;
+  private final FeedRepository feedRepository;
 
   /**
    * 기상청 단기 예보 API 요청 및 데이터 파싱을 거쳐 나온<br>날씨 데이터를 저장하고 반환
@@ -70,10 +76,11 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
     }
 
     // 이전 데이터 삭제
+//    deleteOldForecast(weatherList.get(0).getLocation());
     Instant cutoffTime = LocalDate.now(KST).atStartOfDay(KST).toInstant();
-    List<Weather> oldForecast = weatherRepository.getOldForecast(weatherList.get(0).getLocation(),
+    int deleted = weatherRepository.deleteOldOrphanForecast(weatherList.get(0).getLocation(),
         cutoffTime);
-    weatherRepository.deleteAll(oldForecast);
+    log.info("{} weather data deleted", deleted);
 
     // 데이터 저장
     weatherRepository.saveAll(weatherList);
@@ -147,6 +154,27 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
         .map(t -> t.format(DateTimeFormatter.ofPattern("HHmm")))
         // 아무것도 없으면 기본 값 제공
         .orElse("0200");
+  }
+
+  private void deleteOldForecast(Location location) {
+    // 자를 시간
+    Instant cutoffTime = LocalDate.now(KST).atStartOfDay(KST).toInstant();
+
+    // 시간 기준 이전 데이터(오래된 예보 데이터) 가져오기
+    List<Weather> oldForecast = weatherRepository.getOldForecast(location,
+        cutoffTime);
+
+    // Feed에 사용 중인 날씨 ID 가져오기
+    List<UUID> weatherIdsInUse = feedRepository.findWeatherIdsInUse(oldForecast);
+    Set<UUID> weatherIdsInUseSet = new HashSet<>(weatherIdsInUse);
+
+    // 필터링
+    List<Weather> deleteTarget = oldForecast.stream()
+        .filter(weather -> !weatherIdsInUseSet.contains(weather.getId()))
+        .collect(Collectors.toList());
+
+    // 필터링 된 날씨 데이터만 삭제
+    weatherRepository.deleteAll(deleteTarget);
   }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImpl.java
@@ -12,7 +12,6 @@ import com.codeit.weatherwear.domain.weather.service.WeatherFetchService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -23,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,10 +54,6 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
    * @param longitude 경도
    * @return 날씨 엔티티 리스트
    */
-  // 쿼리가 실행된 후 영속성 컨텍스트를 자동으로 clear()하여 캐시된 엔티티 비움
-  // 삭제 쿼리를 @Modifying을 통해 JPA의 Dirty Checking을 거치지 않고 직접 SQL로 수행하도록 했기에 아래 어노테이션 추가
-  // 기존 날씨 예보 엔티티 삭제는 대량 삭제에 해당되어서 빠르게 수행하는 것이 더 좋다고 생각
-  @Modifying(clearAutomatically = true)
   @Transactional
   @Override
   public List<Weather> fetchAndStoreWeather(double latitude, double longitude) {
@@ -71,12 +65,6 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
     if (weatherList.isEmpty()) {
       return Collections.emptyList();
     }
-
-    // 이전 데이터 삭제
-    Instant cutoffTime = LocalDate.now(KST).atStartOfDay(KST).toInstant();
-    int deleted = weatherRepository.deleteOldOrphanForecast(weatherList.get(0).getLocation(),
-        cutoffTime);
-    log.info("{} weather data deleted", deleted);
 
     // 데이터 저장
     weatherRepository.saveAll(weatherList);

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherServiceImpl.java
@@ -53,6 +53,7 @@ public class WeatherServiceImpl implements WeatherService {
 
     Instant todayStart = today.atStartOfDay(KST).toInstant();    // 오늘 00:00
     List<Weather> weatherList = weatherRepository.findRecentWeathers(location, todayStart);
+    log.info("locations: {}", weatherList);
 
     if (weatherList.isEmpty()) {
       // 없다면 가져오기

--- a/src/test/java/com/codeit/weatherwear/domain/location/service/LocationServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/location/service/LocationServiceImplTest.java
@@ -82,9 +82,8 @@ class LocationServiceImplTest {
     LocationDto mockLocationDto = createMockLocationDto(40.2, 127.9, 10, 20,
         List.of("서울", "송파구", "신천동"));
     Location existingLocation = createMockLocationByDto(mockLocationDto);
-    given(locationRepository.findLocationByNameAndLatitudeAndLongitude(
-        existingLocation.getName(), existingLocation.getLatitude(),
-        existingLocation.getLongitude())).willReturn(
+    given(locationRepository.findLocationByName(
+        existingLocation.getName())).willReturn(
         Optional.of(existingLocation));
 
     // when
@@ -102,9 +101,8 @@ class LocationServiceImplTest {
     LocationDto mockLocationDto = createMockLocationDto(40.2, 127.9, 10, 20,
         List.of("서울", "송파구", "신천동"));
     Location createLocation = createMockLocationByDto(mockLocationDto);
-    given(locationRepository.findLocationByNameAndLatitudeAndLongitude(
-        createLocation.getName(), createLocation.getLatitude(),
-        createLocation.getLongitude())).willReturn(
+    given(locationRepository.findLocationByName(
+        createLocation.getName())).willReturn(
         Optional.empty());
     given(locationRepository.save(any(Location.class))).willReturn(createLocation);
 
@@ -124,9 +122,8 @@ class LocationServiceImplTest {
     List<String> names = Arrays.asList("서울", null, " ", "", "송파구", "   ", "신천동");
     LocationDto mockLocationDto = createMockLocationDto(40.2, 127.9, 10, 20, names);
     Location createLocation = createMockLocationByDto(mockLocationDto);
-    given(locationRepository.findLocationByNameAndLatitudeAndLongitude(
-        createLocation.getName(), createLocation.getLatitude(),
-        createLocation.getLongitude())).willReturn(
+    given(locationRepository.findLocationByName(
+        createLocation.getName())).willReturn(
         Optional.empty());
     given(locationRepository.save(any(Location.class))).willReturn(createLocation);
 
@@ -153,8 +150,8 @@ class LocationServiceImplTest {
 
     given(lamcUtils.convertToGrid(latitude, longitude)).willReturn(point);
     given(locationApiClient.getRegionNames(latitude, longitude)).willReturn(addrList);
-    given(locationRepository.findLocationByNameAndLatitudeAndLongitude(
-        location.getName(), location.getLatitude(), location.getLongitude())).willReturn(
+    given(locationRepository.findLocationByName(
+        location.getName())).willReturn(
         Optional.of(location));
 
     // when

--- a/src/test/java/com/codeit/weatherwear/domain/weather/assembler/WeatherAssemblerTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/weather/assembler/WeatherAssemblerTest.java
@@ -6,6 +6,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import com.codeit.weatherwear.domain.location.entity.Location;
+import com.codeit.weatherwear.domain.weather.entity.Humidity;
+import com.codeit.weatherwear.domain.weather.entity.Temperature;
 import com.codeit.weatherwear.domain.weather.entity.Weather;
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiData;
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiDataId;
@@ -55,8 +57,18 @@ class WeatherAssemblerTest {
   @DisplayName("assemble: 정상 입력 시 Weather 객체 생성 및 필드 매핑")
   void assemble_success() {
     // when
+    Weather previousWeather = mock(Weather.class);
+    Humidity prevHumidity = mock(Humidity.class);
+    Temperature prevTemp = mock(Temperature.class);
+
+    given(previousWeather.getHumidity()).willReturn(prevHumidity);
+    given(prevHumidity.getCurrent()).willReturn(48.0);
+
+    given(previousWeather.getTemperature()).willReturn(prevTemp);
+    given(prevTemp.getCurrent()).willReturn(21.0);
+
     Weather weather = weatherAssembler.assemble(
-        "20250710", "20250709", categoryMap, location, groupedApiData
+        "20250710", "20250709", categoryMap, location, previousWeather
     );
 
     // then
@@ -105,15 +117,10 @@ class WeatherAssemblerTest {
 
   private void setCategoryMapReturnValue(Map<String, WeatherApiData> categoryMap) {
     // 값 세팅 - mock 반환값 설정
-    given(helper.extractMinForecastTime(categoryMap)).willReturn("0500");
     given(helper.getFcstValue(categoryMap, "REH")).willReturn("50");
     given(helper.getFcstValue(categoryMap, "TMP")).willReturn("20");
     given(helper.parseDoubleOrNull("50")).willReturn(50.0);
     given(helper.parseDoubleOrNull("20")).willReturn(20.0);
-    given(helper.calculateDifferenceFromPreviousDay(50.0, "REH", "20250710", "0500",
-        groupedApiData)).willReturn(2.0);
-    given(helper.calculateDifferenceFromPreviousDay(20.0, "TMP", "20250710", "0500",
-        groupedApiData)).willReturn(-1.0);
     given(helper.parseMinMaxTempDoubleOrNull(tmx)).willReturn(25.0);
     given(helper.parseMinMaxTempDoubleOrNull(tmn)).willReturn(15.0);
     given(helper.parseDoubleOrNull("1.2")).willReturn(1.2);

--- a/src/test/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepositoryTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/weather/repository/WeatherRepositoryTest.java
@@ -40,7 +40,7 @@ class WeatherRepositoryTest {
 
   @Test
   @DisplayName("특정 위치와 기준 시간 이후의 Weather만 조회된다")
-  void findRecentWeathers_success() {
+  void findOneDayWeathers_success() {
     // given
     double latitude = 37.5759;
     double longitude = 126.9768;

--- a/src/test/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherConvertServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherConvertServiceImplTest.java
@@ -16,6 +16,7 @@ import com.codeit.weatherwear.domain.weather.entity.SkyStatus;
 import com.codeit.weatherwear.domain.weather.entity.Weather;
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiData;
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiDataId;
+import com.codeit.weatherwear.domain.weather.repository.WeatherRepository;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,9 @@ class WeatherConvertServiceImplTest {
 
   @Mock
   private WeatherAssembler weatherAssembler;
+
+  @Mock
+  private WeatherRepository weatherRepository;
 
   private String baseDate, baseTime, fcstDate;
 
@@ -82,7 +86,7 @@ class WeatherConvertServiceImplTest {
         anyString(),
         anyMap(),
         any(Location.class),
-        anyMap()
+        any()
     )).willReturn(weather);
 
     // when
@@ -122,7 +126,7 @@ class WeatherConvertServiceImplTest {
         anyString(),
         anyMap(),
         any(Location.class),
-        anyMap()
+        any()
     )).willThrow(new RuntimeException("변환 실패"));
 
     // when
@@ -165,7 +169,7 @@ class WeatherConvertServiceImplTest {
 
     // WeatherAssembler가 호출될 때 결과 반환
     given(weatherAssembler.assemble(
-        eq(fcstDate), eq(baseDate), anyMap(), eq(location), eq(groupedApiData)
+        eq(fcstDate), eq(baseDate), anyMap(), eq(location), any()
     )).willReturn(weather);
 
     // when
@@ -179,7 +183,7 @@ class WeatherConvertServiceImplTest {
     // weatherAssembler.assemble가 정확히 아래 인자들로 호출됐는지 검증
     // 세 번째 인자(categoryMap)를 ArgumentCaptor로 캡처
     verify(weatherAssembler).assemble(
-        eq(fcstDate), eq(baseDate), captor.capture(), eq(location), eq(groupedApiData)
+        eq(fcstDate), eq(baseDate), captor.capture(), eq(location), any()
     );
 
     // 캡처된 categoryMap을 꺼내서 기대한 값과 일치하는지 확인


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#235 #227 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [x] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [x] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

fix/235/fix-weather-location-bug -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

버그 리포트 중 날씨, 위치 도메인 관련 아래의 문제들을 해결하였습니다.
-  1. 같은 지역인데 Location이 새로 등록되는 현상
- 2. 날씨 데이터 관련 전일 대비 데이터 계산 값 기준 및 정확도 확인
- 3. Feed에 등록된 날씨도 함께 삭제되면서 연관관계 오류가 발생하는 이슈

추가적으로 관련 버그들을 해결하며 날씨 예보 요청 시 수행하는 삭제 로직 관련 리팩토링을 진행하였습니다.
관련 내용은 추가 코멘트에 작성하였으니 참고해주시면 감사하겠습니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

전체 테스트 코드는 성공적으로 수행되었습니다.
배치 또한 확인했을 때, 성공적으로 잘 수행되었습니다.

<img width="961" height="490" alt="image" src="https://github.com/user-attachments/assets/4b53bc6d-7993-4428-a6bc-23baf18d9756" />

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

###  🔊 추가 코멘트
#### 날씨 예보 요청 시 수행하는 삭제 로직 관련 리팩토링 관련
우선, 3번째의 `Feed에 등록된 날씨도 함께 삭제되면서 연관관계 오류가 발생하는 이슈` 관련 버그 픽스를 진행하면서 생긴 고민이었습니다.
실제로 날씨 예보를 새로 요청하면서, 기존 날씨를 삭제하는 로직도 함께 수행하도록 했습니다.
잘 생각해보니 그렇게 된다면 날씨 예보가 존재하지 않는 위치에 대한 예보 한 번을 조회하는데에 매번 삭제라는 요청을 수행하는 것은 과하지 않은가?에 대한 생각이 들었습니다.
지금은 사용자가 없어 큰 문제가 되진 않지만, 만약 트래픽이 몰리거나 기타 예외적인 사건이 발생하게 되었을 때 삭제 로칙을 수행하는 것이 DB에게 상당한 부담이 될 것 같아 수정해야겠다고 판단했습니다.

실제로 바로바로 삭제해야 하는 이유도 딱히 없었기 때문에 한 번에 삭제하는 bulk delete 방식에 대해 생각하게 되었고,
일단은 날씨 예보를 정기적으로 불러온 후, 해당 Batch 처리가 완료된 후에 삭제를 진행하는 것으로 로직을 설계하였습니다.
매일 날씨 예보 요청 Batch 처리가 끝나면 기존에 쓸모 없는 데이터 삭제를 진행하는 것입니다.

- 삭제 주기
  일주일이나 한 달, 이 정도의 기간을 가져도 될 것 같긴 합니다만, 일단은 매일 삭제하는 것으로 일단은 두었습니다.
  그러나 지금 생각했을 때는 매 주마다 수행하는게 나을 수도 있겠네요, 이 부분은 좀 고민해보도록 하겠습니다. ㅎㅎ.

- bulk delete 방식으로 사용한 이유.
  Spring Batch를 통해 삭제도 가능했는데, 저는 매 번 삭제 로직이 불려와서 DB의 자원을 낭비하는게 추후 데이터 양이 많아진다면 부담되지 않을까 생각이 들어서 한 번에 삭제를 하고 싶었습니다. 그래서 bulk delete 방식을 사용했는데요.
  또한, 날씨 예보를 요청하는 로직에서 삭제 로직을 빼고, 단순히 Batch 작업 시에만 삭제를 하는 것으로 수정하여, JPA 라이프 사이클보다 속도 측면에서 강점이 있는 @Modifying을 통한 직접 SQL 삭제 진행을 수행하게끔 하였습니다. 그 대신, 영속성 컨텍스트에 영향이 생길 수도 있으니 해당 부분은 `clearAutomatically = true`를 통해 영속성 컨텍스트를 자동으로 초기화하여 데이터 불일치를 방지하도록 하였습니다.
이만, 총총.