### PR TITLE
Fix: 피드 상세 조회 시 의상 세부 속성이 표시되지 않는 현상 해결

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -27,6 +27,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;                     # 실제 클라이언트 IP
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; # 프록시 체인
+        proxy_set_header X-Forwarded-Port $server_port;              # 클라이언트가 사용한 포트 정보를 전달
         proxy_set_header X-Forwarded-Proto $scheme;                  # http or https
         proxy_set_header Authorization $http_authorization;          # 요청을 프록시할 때 Authorization 헤더를 전달
 
@@ -42,9 +43,10 @@ server {
 
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Real-IP $remote_addr;
 
         proxy_connect_timeout 5s;
         proxy_send_timeout 60s;

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/mapper/ClothMapper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/mapper/ClothMapper.java
@@ -1,7 +1,6 @@
 package com.codeit.weatherwear.domain.clothes.mapper;
 
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesAttributeWithDefDto;
-import com.codeit.weatherwear.domain.clothes.dto.response.ClothesAttributeDefDto;
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
 import com.codeit.weatherwear.domain.clothes.entity.Cloth;
 import com.codeit.weatherwear.domain.clothes.entity.ClothWithAttributes;
@@ -35,11 +34,15 @@ public class ClothMapper {
 
   }
 
-  public List<ClothesAttributeDefDto> toAttributeDefDto(List<ClothWithAttributes> attrs) {
+  public List<ClothesAttributeWithDefDto> toAttributeDefDto(List<ClothWithAttributes> attrs) {
     return attrs
         .stream().map(
-            attr -> new ClothesAttributeDefDto(attr.getId(), attr.getAttribute().getName(),
-                attr.getAttribute().getSelectableValues())
+            attr -> new ClothesAttributeWithDefDto(
+                attr.getId(),
+                attr.getAttribute().getName(),
+                attr.getAttribute().getSelectableValues(),
+                attr.getValue()
+            )
         )
         .toList();
   }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/mapper/ClothMapper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/mapper/ClothMapper.java
@@ -38,7 +38,7 @@ public class ClothMapper {
     return attrs
         .stream().map(
             attr -> new ClothesAttributeWithDefDto(
-                attr.getId(),
+                attr.getAttribute().getId(),
                 attr.getAttribute().getName(),
                 attr.getAttribute().getSelectableValues(),
                 attr.getValue()

--- a/src/main/java/com/codeit/weatherwear/domain/ootd/dto/response/OotdDto.java
+++ b/src/main/java/com/codeit/weatherwear/domain/ootd/dto/response/OotdDto.java
@@ -1,6 +1,6 @@
 package com.codeit.weatherwear.domain.ootd.dto.response;
 
-import com.codeit.weatherwear.domain.clothes.dto.response.ClothesAttributeDefDto;
+import com.codeit.weatherwear.domain.clothes.dto.response.ClothesAttributeWithDefDto;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
@@ -14,5 +14,5 @@ public class OotdDto {
   private final String name;
   private final String imageUrl;
   private final String type;
-  private final List<ClothesAttributeDefDto> attributes;
+  private final List<ClothesAttributeWithDefDto> attributes;
 }

--- a/src/main/java/com/codeit/weatherwear/domain/ootd/mapper/OotdMapper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/ootd/mapper/OotdMapper.java
@@ -1,12 +1,11 @@
 package com.codeit.weatherwear.domain.ootd.mapper;
 
-import com.codeit.weatherwear.domain.clothes.dto.response.ClothesAttributeWithDefDto;
 import com.codeit.weatherwear.domain.clothes.entity.Cloth;
+import com.codeit.weatherwear.domain.clothes.mapper.ClothMapper;
 import com.codeit.weatherwear.domain.feed.entity.Feed;
 import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
 import com.codeit.weatherwear.domain.ootd.entity.Ootd;
 import com.codeit.weatherwear.global.storage.ThumbnailImageStorage;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +13,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OotdMapper {
 
+  private final ClothMapper clothMapper;
   private final ThumbnailImageStorage thumbnailImageStorage;
 
   public Ootd toEntity(Feed feed, Cloth cloth) {
@@ -29,22 +29,12 @@ public class OotdMapper {
         cloth.getClothesImageUrl() != null ? thumbnailImageStorage.get(cloth.getClothesImageUrl())
             : null;
 
-    List<ClothesAttributeWithDefDto> clothesAttributeWithDefDtos = cloth.getClothesWithAttributes()
-        .stream()
-        .map(attr -> new ClothesAttributeWithDefDto(
-            attr.getAttribute().getId(),
-            attr.getAttribute().getName(),
-            attr.getAttribute().getSelectableValues(),
-            attr.getValue()
-        ))
-        .toList();
-
     return OotdDto.builder()
         .clothesId(cloth.getId())
         .name(cloth.getName())
         .imageUrl(imageUrl)
         .type(cloth.getClothType().toString())
-        .attributes(clothesAttributeWithDefDtos)
+        .attributes(clothMapper.toAttributeDefDto(cloth.getClothesWithAttributes()))
         .build();
   }
 

--- a/src/main/java/com/codeit/weatherwear/domain/ootd/mapper/OotdMapper.java
+++ b/src/main/java/com/codeit/weatherwear/domain/ootd/mapper/OotdMapper.java
@@ -1,11 +1,12 @@
 package com.codeit.weatherwear.domain.ootd.mapper;
 
+import com.codeit.weatherwear.domain.clothes.dto.response.ClothesAttributeWithDefDto;
 import com.codeit.weatherwear.domain.clothes.entity.Cloth;
-import com.codeit.weatherwear.domain.clothes.mapper.ClothMapper;
 import com.codeit.weatherwear.domain.feed.entity.Feed;
 import com.codeit.weatherwear.domain.ootd.dto.response.OotdDto;
 import com.codeit.weatherwear.domain.ootd.entity.Ootd;
 import com.codeit.weatherwear.global.storage.ThumbnailImageStorage;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +14,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OotdMapper {
 
-  private final ClothMapper clothMapper;
   private final ThumbnailImageStorage thumbnailImageStorage;
 
   public Ootd toEntity(Feed feed, Cloth cloth) {
@@ -29,12 +29,22 @@ public class OotdMapper {
         cloth.getClothesImageUrl() != null ? thumbnailImageStorage.get(cloth.getClothesImageUrl())
             : null;
 
+    List<ClothesAttributeWithDefDto> clothesAttributeWithDefDtos = cloth.getClothesWithAttributes()
+        .stream()
+        .map(attr -> new ClothesAttributeWithDefDto(
+            attr.getAttribute().getId(),
+            attr.getAttribute().getName(),
+            attr.getAttribute().getSelectableValues(),
+            attr.getValue()
+        ))
+        .toList();
+
     return OotdDto.builder()
         .clothesId(cloth.getId())
         .name(cloth.getName())
         .imageUrl(imageUrl)
         .type(cloth.getClothType().toString())
-        .attributes(clothMapper.toAttributeDefDto(cloth.getClothesWithAttributes()))
+        .attributes(clothesAttributeWithDefDtos)
         .build();
   }
 


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#244 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

fix/244/feed-cloth-attr-fix -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

속성을 표시하는 DTO에서 ClothesAttributeWithDefDto로 수정하여 의상 세부 속성이 피드에서도 표시되도록 하였습니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

<img width="949" height="586" alt="image" src="https://github.com/user-attachments/assets/6d561d6e-4a05-4778-be5f-997036fc6f29" />

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.