### PR TITLE
[Bug]지그재그 Jsoup 작동전 검사 실행

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -18,7 +18,6 @@ import com.codeit.weatherwear.domain.clothes.mapper.ClothMapper;
 import com.codeit.weatherwear.domain.clothes.repository.AttributeRepository;
 import com.codeit.weatherwear.domain.clothes.repository.ClothRepository;
 import com.codeit.weatherwear.domain.clothes.service.parser.SiteParser;
-import com.codeit.weatherwear.domain.clothes.service.parser.ZigZagParser;
 import com.codeit.weatherwear.domain.recommendation.service.AIRecommendationService;
 import com.codeit.weatherwear.domain.user.entity.User;
 import com.codeit.weatherwear.domain.user.exception.UserNotFoundException;
@@ -41,7 +40,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Slice;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.annotation.Backoff;
@@ -137,6 +135,17 @@ public class ClothServiceImpl implements ClothService {
     int retryCount = Optional.ofNullable(RetrySynchronizationManager.getContext())
         .map(RetryContext::getRetryCount)
         .orElse(1);
+
+    //지그재그일 경우 Jsoup 작동안함, Selenium 작동
+    if (url.contains("zigzag.kr")) {
+      SiteParser zigzagParser = siteParsers.stream()
+          .filter(p -> p.supports(url))
+          .findFirst()
+          .orElseThrow(() -> new ExtractionException("ZigZag 사이트가 아닙니다."));
+      return zigzagParser.extract(url);
+    }
+
+    //나머지 사이트 - Jsoup
     try {
       Document document = Jsoup.connect(url)
           .timeout(15000)
@@ -152,7 +161,7 @@ public class ClothServiceImpl implements ClothService {
             return new NotSupportSiteException(url);
           });
 
-      return parser.extract(url, document);
+      return parser.extract(document);
     } catch (IOException e) {
       log.warn("[Fail Getting Cloth From Url] Retry count: {}", retryCount);
       throw new RuntimeException(e);
@@ -160,6 +169,7 @@ public class ClothServiceImpl implements ClothService {
       log.warn("[Fail Getting Cloth From Url] Retry count: {}", retryCount);
       throw e;
     }
+
   }
 
   @Recover

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/ClothServiceImpl.java
@@ -141,7 +141,11 @@ public class ClothServiceImpl implements ClothService {
       SiteParser zigzagParser = siteParsers.stream()
           .filter(p -> p.supports(url))
           .findFirst()
-          .orElseThrow(() -> new ExtractionException("ZigZag 사이트가 아닙니다."));
+          .orElseThrow(() -> {
+            log.debug("[Fail Extracting Cloth] Not ZigZag Site - URL: {}", url);
+            return new ExtractionException(url);
+          });
+
       return zigzagParser.extract(url);
     }
 

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/MusinsaParser.java
@@ -25,7 +25,12 @@ public class MusinsaParser implements SiteParser {
   }
 
   @Override
-  public ClothesDto extract(String url, Document document) {
+  public ClothesDto extract(String url) {
+    throw new UnsupportedOperationException("Musinsa는 Selenium 기반 추출을 지원하지 않습니다.");
+  }
+
+  @Override
+  public ClothesDto extract(Document document) {
     log.info("[Start Extracting Musinsa Cloth]");
     try {
       Element scriptTag = document.selectFirst("script#pdp-data");

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/SiteParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/SiteParser.java
@@ -7,5 +7,7 @@ public interface SiteParser {
 
   boolean supports(String url);
 
-  ClothesDto extract(String url, Document document);
+  ClothesDto extract(String url);
+
+  ClothesDto extract(Document document);
 }

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/TwentyNineCmParser.java
@@ -16,7 +16,12 @@ public class TwentyNineCmParser implements SiteParser {
   }
 
   @Override
-  public ClothesDto extract(String url, Document document) {
+  public ClothesDto extract(String url) {
+    throw new UnsupportedOperationException("29CM는 Selenium 기반 추출을 지원하지 않습니다.");
+  }
+
+  @Override
+  public ClothesDto extract(Document document) {
     log.info("[Start Extracting 29cm Cloth]");
     String name = document.title();
     String imageUrl = extractOgImage(document);

--- a/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/clothes/service/parser/ZigZagParser.java
@@ -1,7 +1,6 @@
 package com.codeit.weatherwear.domain.clothes.service.parser;
 
 import com.codeit.weatherwear.domain.clothes.dto.response.ClothesDto;
-import com.codeit.weatherwear.domain.clothes.exception.cloth.ExtractionException;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,7 +8,6 @@ import org.jsoup.nodes.Document;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.stereotype.Component;
@@ -27,7 +25,7 @@ public class ZigZagParser implements SiteParser {
   }
 
   @Override
-  public ClothesDto extract(String url, Document document) {
+  public ClothesDto extract(String url) {
     log.info("[Start Extracting ZigZag Cloth]");
     WebDriver driver = webDriverProvider.getWebDriver();
     try {
@@ -48,5 +46,10 @@ public class ZigZagParser implements SiteParser {
     } finally {
       driver.quit();
     }
+  }
+
+  @Override
+  public ClothesDto extract(Document document) {
+    throw new UnsupportedOperationException("Zigzag는 Jsoup 기반 추출을 지원하지 않습니다.");
   }
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #243 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📑 변경 사항
제가 바보같은 행동을 했더라구요.
> 버그 발생 원인: 지그재그는 Jsoup 작동안함
```
Document document = Jsoup.connect(url)
...
return parser.extract(url, document);
```
기존에는 Jsoup으로 html가져오고 `parser.extract`로 ZigZagParser가 작동하게 됨.
당연히? 지그재그 오류남
지그재그 사이트는 해당 로직을 거치면 안됨
> 해결방법: if문으로 지그재그 사이트 경우 따로 return되도록 설정하였습니다.

### 🛠 테스트 결과
> 
로컬에서 실행했을때, 모든 사이트 작동 확인하였습니다.

### ✅ PR 올리기 전 체크리스트

- [ ] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [ ] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.

### 추가코멘트 
해당 pr이 merge되어야 배포사이트에서 확인할 수 있는걸로 알고있어 배포된 사이트에서는 확인하지 못하였습니다.