### PR TITLE
Fix: OAuth2 - authorization_request_not_found 에러 해결

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/security/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import com.codeit.weatherwear.domain.security.customauthentication.jwt.JwtAuthen
 import com.codeit.weatherwear.domain.security.customauthentication.jwt.JwtLogoutHandler;
 import com.codeit.weatherwear.domain.security.customauthentication.oauth2.CustomOAuth2SuccessHandler;
 import com.codeit.weatherwear.domain.security.customauthentication.oauth2.CustomOAuth2UserService;
+import com.codeit.weatherwear.domain.security.customauthentication.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.codeit.weatherwear.domain.security.service.JwtSessionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -50,7 +51,8 @@ public class SecurityConfig {
       JwtLogoutHandler jwtLogoutHandler,
       CustomOAuth2UserService customOAuth2UserService,
       @Qualifier("customOAuth2SuccessHandler") AuthenticationSuccessHandler customOAuth2SuccessHandler,
-      @Qualifier("customOAuth2FailureHandler") AuthenticationFailureHandler customOAuth2FailureHandler)
+      @Qualifier("customOAuth2FailureHandler") AuthenticationFailureHandler customOAuth2FailureHandler,
+      HttpCookieOAuth2AuthorizationRequestRepository cookieOAuth2AuthorizationRequestRepository)
       throws Exception {
 
     httpSecurity
@@ -62,10 +64,14 @@ public class SecurityConfig {
         .addFilterAt(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .addFilterAfter(jwtAuthenticationFilter, CustomAuthenticationFilter.class)
         .oauth2Login(oauth2 -> oauth2
-            .userInfoEndpoint(userInfo -> userInfo
-                .userService(customOAuth2UserService))
-            .successHandler(customOAuth2SuccessHandler)
-            .failureHandler(customOAuth2FailureHandler)
+                .userInfoEndpoint(userInfo -> userInfo
+                    .userService(customOAuth2UserService))
+                .successHandler(customOAuth2SuccessHandler)
+                .failureHandler(customOAuth2FailureHandler)
+                .authorizationEndpoint(authEndpoint -> authEndpoint
+                    .authorizationRequestRepository(cookieOAuth2AuthorizationRequestRepository)
+                )
+            // 인증 요청을 쿠키에 저장하고 검색
         )
         .sessionManagement(session -> session
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CookieUtils.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CookieUtils.java
@@ -1,0 +1,56 @@
+package com.codeit.weatherwear.domain.security.customauthentication.oauth2;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Base64;
+import java.util.Optional;
+import org.springframework.util.SerializationUtils;
+
+public class CookieUtils {
+
+  public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies != null && cookies.length > 0) {
+      for (Cookie cookie : cookies) {
+        if (cookie.getName().equals(name)) {
+          return Optional.of(cookie);
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  public static void addCookie(HttpServletResponse response, String name, String value,
+      int maxAge) {
+    Cookie cookie = new Cookie(name, value);
+    cookie.setPath("/");
+    cookie.setHttpOnly(true);
+    cookie.setMaxAge(maxAge);
+    response.addCookie(cookie);
+  }
+
+  public static void deleteCookie(HttpServletRequest request, HttpServletResponse response,
+      String name) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies != null && cookies.length > 0) {
+      for (Cookie cookie : cookies) {
+        if (cookie.getName().equals(name)) {
+          cookie.setValue("");
+          cookie.setPath("/");
+          cookie.setMaxAge(0);
+          response.addCookie(cookie);
+        }
+      }
+    }
+  }
+
+  public static String serialize(Object object) {
+    return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+  }
+
+  public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+    return cls.cast(
+        SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CookieUtils.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CookieUtils.java
@@ -25,6 +25,7 @@ public class CookieUtils {
       int maxAge) {
     Cookie cookie = new Cookie(name, value);
     cookie.setPath("/");
+    cookie.setAttribute("SameSite", "Lax");
     cookie.setHttpOnly(true);
     cookie.setMaxAge(maxAge);
     response.addCookie(cookie);
@@ -38,6 +39,7 @@ public class CookieUtils {
         if (cookie.getName().equals(name)) {
           cookie.setValue("");
           cookie.setPath("/");
+          cookie.setAttribute("SameSite", "Lax");
           cookie.setMaxAge(0);
           response.addCookie(cookie);
         }

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2FailureHandler.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2FailureHandler.java
@@ -33,8 +33,13 @@ public class CustomOAuth2FailureHandler implements
       switch (error.getErrorCode()) {
         case "ACCOUNT_LOCKED" -> status = HttpServletResponse.SC_UNAUTHORIZED; // 잠금 계정이면 401
         case "USER_ALREADY_EXISTS" -> status = HttpServletResponse.SC_BAD_REQUEST; // 사용자 중복이면 400
-        default -> {
+        case "authorization_request_not_found" -> {
           status = HttpServletResponse.SC_BAD_REQUEST;
+          errorMessage = "인증 요청 정보가 유실되었습니다. 다시 시도해주세요.";
+        }
+        default -> {
+          status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+          errorMessage = "처리 중 문제가 생겼습니다. 다시 시도해주세요.";
           log.warn("Undefined OAuth2 SignIn ErrorCode: {}", error.getErrorCode());
         }
       }

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2UserService.java
@@ -74,7 +74,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       User user = optionalUser.get();
       // 계정이 잠금 상태면 로그인 불가능
       if (user.isLocked()) {
-        log.info("소셜 로그인 - 잠금 계정");
+        log.info("OAuth sign-in : Locked Account tried to sign in");
         throw new OAuth2AuthenticationException(
             new OAuth2Error(ErrorCode.ACCOUNT_LOCKED.name(), ErrorCode.ACCOUNT_LOCKED.getMessage(),
                 null));

--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,56 @@
+package com.codeit.weatherwear.domain.security.customauthentication.oauth2;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements
+    AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+  public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+  public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+  private static final int cookieExpireSeconds = 180;
+
+  @Override
+  public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+    OAuth2AuthorizationRequest oAuth2AuthorizationRequest = CookieUtils.getCookie(request,
+            OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+        .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+        .orElse(null);
+    return oAuth2AuthorizationRequest;
+  }
+
+  @Override
+  public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+      HttpServletRequest request, HttpServletResponse response) {
+    if (authorizationRequest == null) {
+      removeAuthorizationRequest(request, response);
+      return;
+    }
+
+    CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+        CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+    String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+    if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+      CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin,
+          cookieExpireSeconds);
+    }
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+      HttpServletResponse response) {
+    return this.loadAuthorizationRequest(request);
+  }
+
+  public void removeAuthorizationRequestCookies(HttpServletRequest request,
+      HttpServletResponse response) {
+    CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+    CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+  }
+
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

참고: https://www.notion.so/23e97c15da0880a2a502c1886374e5a1

소셜 로그인 시도 시 아래처럼 응답이 나오는 문제 
```
{
  "status": 400,
  "message": "null"
} 
```

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

feat/107/oauth -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

상은님이 구글 로그인 시도 중 아래와 같이 원인을 알기 어려운 응답을 받았다고 공유해주셨습니다.

```
{
  "status": 400,
  "message": "null"
}
```
제가 직접 재현해본 결과, 대부분의 경우 정상 작동했지만, 로그인 과정에서 뒤로 가기 후 재시도하거나 페이지 새로고침 등 흐름이 비정상적으로 진행되는 경우, 동일한 오류가 발생했습니다.

로그를 살펴보니 아래와 같은 예외가 발생했습니다:

> CustomOAuth2FailureHandler : Undefined OAuth2 SignIn ErrorCode: authorization_request_not_found

이 오류는 OAuth2 인증 요청 중 세션에 저장된 OAuth2AuthorizationRequest 객체를 찾지 못했을 때 발생합니다.

Spring Security는 사용자가 OAuth 공급자를 통해 인증을 마치고 돌아왔을 때, 세션에 저장되어 있던 요청 정보와 비교해 유효성을 검증합니다. 그런데 SessionCreationPolicy.STATELESS 설정으로 인해 세션이 없거나 만료된 상태라면 인증 흐름이 끊기고 위 오류가 발생합니다.

우리 서비스는 JWT 기반 인증을 사용하며 stateless 설정이 되어 있으므로, OAuth2 흐름과 충돌이 있었던 것으로 보입니다.

실제로는 대부분 문제없이 로그인되지만, 흐름이 깨질 경우 의미 없는 "message": "null" 응답이 반환되어 사용자와 개발자 모두 원인을 파악하기 어려운 상황이었습니다.

따라서,

- 예외 메시지를 명확히 로깅하고 클라이언트 응답 메시지도 더 직관적으로 개선하였으며,(핸들러 수정)
- 세션 대신 쿠키에 OAuth2 요청 정보를 저장하는 방식을 도입했습니다. (분산 서버를 사용한다면 Redis에 요청 정보를 저장하는 방식도 많이 사용한다고 합니다.)

이로 인해 authorization_request_not_found 오류는 앞으로 발생하지 않을 것으로 예상합니다.

참고로 관련 내용을 잘 정리한 글이 있어 함께 공유드립니다:[Spring Security OAuth2 authorization_request_not_found 에러](https://velog.io/@smc2315/authorization-request-not-found#3-default-authorizationrequestrepository%EB%A5%BC-cookie-%EA%B8%B0%EB%B0%98-%EC%A0%80%EC%9E%A5%EC%86%8C%EB%A1%9C-%EB%B3%80%EA%B2%BD---%EC%B1%84%ED%83%9D%ED%95%9C-%EB%B0%A9%EC%8B%9D-)

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

<img width="239" height="21" alt="image" src="https://github.com/user-attachments/assets/f2aa0b58-f25c-4035-80e2-da7ad86eadee" />


### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.