### PR TITLE
Fix: oauth redirect uri를 환경변수로 변경

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/customauthentication/oauth2/CustomOAuth2UserService.java
@@ -76,7 +76,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       if (user.isLocked()) {
         log.info("OAuth sign-in : Locked Account tried to sign in");
         throw new OAuth2AuthenticationException(
-            new OAuth2Error(ErrorCode.ACCOUNT_LOCKED.name(), ErrorCode.ACCOUNT_LOCKED.getMessage(),
+            new OAuth2Error(ErrorCode.ACCOUNT_LOCKED.name(), ErrorCode.ACCOUNT_LOCKED.getDetail(),
                 null));
       }
       // 기존 회원이 소셜 연동되어 있지 않다면 연동 정보 추가
@@ -103,7 +103,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       log.info("Fail To Create New User From OAuth2 Provider: User Already Exists");
       throw new OAuth2AuthenticationException(
           new OAuth2Error(ErrorCode.USER_ALREADY_EXISTS.name(),
-              ErrorCode.USER_ALREADY_EXISTS.getMessage(), null));
+              ErrorCode.USER_ALREADY_EXISTS.getDetail(), null));
     }
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,13 +36,13 @@ spring:
           google:
             client-id: ${GOOGLE_OAUTH_CLIENT_ID}
             client-secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "${OAUTH2_BASE_URL:http://localhost:8080/login/oauth2/code}/{registrationId}"
             scope:
               - email
               - profile
           kakao:
             client-id: ${KAKAO_CLIENT_REST_API_KEY}
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "${OAUTH2_BASE_URL:http://localhost:8080/login/oauth2/code}/{registrationId}"
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope:


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- 소셜 로그인 시 redirect uri를 동적으로 생성하면 https/http 프로토콜이 원하는대로 되지 않는 문제가 있어 환경변수로 넣는 방식으로 변경했습니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.

---

### 추가 코멘트

로컬(localhost:8080) 환경에서는 정상 동작을 확인했습니다.
로컬 도커 환경에서도 잘 동작하는지 확인하고 싶었는데 로컬 도커용 db schema.sql이 꼬였는지 계속 drop 후 create 하는데 잘 안 되서 거기서는 정상 동작 확인 못했습니다... 다만 redirect_uri_mismatch 문제는 안 일어나는 걸 보니
배포 환경에서도 괜찮을걸로 예상해서 PR 올립니다.

.env에 환경변수가 추가됐습니다. 댓글로 표시했습니다. test 제외 3개 프로파일에 추가되었으니 확인 부탁드립니다.
https://www.notion.so/env-env-dev-env-prod-env-test-21b97c15da0880d8bdefe80a6316f1d4